### PR TITLE
Remove egui-file-dialog version from examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # egui-file-dialog changelog
 
 ## Unreleased
-/
+### 🔧 Changes
+- Removed the version of `egui-file-dialog` in the examples [#8](https://github.com/fluxxcode/egui-file-dialog/pull/8)
 
 ## 2024-02-03 - v0.1.0
 

--- a/examples/sandbox/Cargo.toml
+++ b/examples/sandbox/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 eframe = { version = "0.25.0", default-features = false, features = ["glow"] }
-egui-file-dialog = { version = "0.1.0", path = "../../"}
+egui-file-dialog = { path = "../../"}

--- a/examples/save_file/Cargo.toml
+++ b/examples/save_file/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 eframe = { version = "0.25.0", default-features = false, features = ["glow"] }
-egui-file-dialog = { version = "0.1.0", path = "../../"}
+egui-file-dialog = { path = "../../"}

--- a/examples/select_directory/Cargo.toml
+++ b/examples/select_directory/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 eframe = { version = "0.25.0", default-features = false, features = ["glow"] }
-egui-file-dialog = { version = "0.1.0", path = "../../"}
+egui-file-dialog = { path = "../../"}

--- a/examples/select_file/Cargo.toml
+++ b/examples/select_file/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 eframe = { version = "0.25.0", default-features = false, features = ["glow"] }
-egui-file-dialog = { version = "0.1.0", path = "../../"}
+egui-file-dialog = { path = "../../"}


### PR DESCRIPTION
Removed the version of `egui-file-dialog` in the examples.