### PR TITLE
Fix syntax highlighting on crates.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### 🔧 Changes
 - Removed the version of `egui-file-dialog` in the examples [#8](https://github.com/fluxxcode/egui-file-dialog/pull/8)
 
+### 📚 Documentation
+- Fix syntax highlighting on crates.io [#9](https://github.com/fluxxcode/egui-file-dialog/pull/9)
+
 ## 2024-02-03 - v0.1.0
 
 Initial release of the file dialog.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ egui-file-dialog = "0.1.0"
 ```
 
 main.rs:
-```rs
+```rust
 use std::path::PathBuf;
 
 use eframe::egui;


### PR DESCRIPTION
Noticed that there is no syntax highlighting for the example on crates.io. \
I assume that it was because I wrote `rs` instead of `rust` in the code block.