### PR TITLE
Add function to set window anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # egui-file-dialog changelog
 
 ## Unreleased
+### ✨ Features
+- Added `FileDialog::anchor` to overwrite the window anchor [#11](https://github.com/fluxxcode/egui-file-dialog/pull/11)
+
 ### 🔧 Changes
 - Removed the version of `egui-file-dialog` in the examples [#8](https://github.com/fluxxcode/egui-file-dialog/pull/8)
 

--- a/examples/sandbox/src/main.rs
+++ b/examples/sandbox/src/main.rs
@@ -14,7 +14,8 @@ struct MyApp {
 impl MyApp {
     pub fn new(_cc: &eframe::CreationContext) -> Self {
         Self {
-            file_dialog: FileDialog::new(),
+            file_dialog: FileDialog::new()
+                .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::new(0.0, 0.0)),
 
             selected_directory: None,
             selected_file: None,


### PR DESCRIPTION
Added new function `FileDialog::anchor` to overwrite the anchor of the window. By default no anchor is set.

Added new private function `FileDialog::create_window` to create the egui window. This allows for more window options in the future.