### PR TITLE
Add functions to set window position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `FileDialog::resizable` to set if the window is resizable [#15](https://github.com/fluxxcode/egui-file-dialog/pull/15)
 - Added `FileDialog::movable` to set if the window is movable [#15](https://github.com/fluxxcode/egui-file-dialog/pull/15)
 - Added `FileDialog::id` to set the ID of the window [#16](https://github.com/fluxxcode/egui-file-dialog/pull/16)
+- Added `FileDialog::fixed_pos` and `FileDialog::default_pos` to set the position of the window [#17](https://github.com/fluxxcode/egui-file-dialog/pull/17)
 
 ### 🔧 Changes
 - Removed the version of `egui-file-dialog` in the examples [#8](https://github.com/fluxxcode/egui-file-dialog/pull/8)

--- a/examples/sandbox/src/main.rs
+++ b/examples/sandbox/src/main.rs
@@ -14,9 +14,7 @@ struct MyApp {
 impl MyApp {
     pub fn new(_cc: &eframe::CreationContext) -> Self {
         Self {
-            file_dialog: FileDialog::new()
-                .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::new(0.0, 0.0))
-                .id("egui_file_dialog"),
+            file_dialog: FileDialog::new().id("egui_file_dialog"),
 
             selected_directory: None,
             selected_file: None,

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -102,6 +102,10 @@ pub struct FileDialog {
     window_overwrite_title: Option<String>,
     /// The ID of the window.
     window_id: Option<egui::Id>,
+    /// The default position of the window.
+    window_default_pos: Option<egui::Pos2>,
+    /// Sets the window position and prevents it from being dragged around.
+    window_fixed_pos: Option<egui::Pos2>,
     /// The default size of the window.
     window_default_size: egui::Vec2,
     /// The anchor of the window.
@@ -158,6 +162,8 @@ impl FileDialog {
             window_title: String::from("Select directory"),
             window_overwrite_title: None,
             window_id: None,
+            window_default_pos: None,
+            window_fixed_pos: None,
             window_default_size: egui::Vec2::new(650.0, 370.0),
             window_anchor: None,
             window_resizable: true,
@@ -199,6 +205,18 @@ impl FileDialog {
     /// Sets the ID of the window.
     pub fn id(mut self, id: impl Into<egui::Id>) -> Self {
         self.window_id = Some(id.into());
+        self
+    }
+
+    /// Sets the default position of the window.
+    pub fn default_pos(mut self, default_pos: impl Into<egui::Pos2>) -> Self {
+        self.window_default_pos = Some(default_pos.into());
+        self
+    }
+
+    /// Sets the window position and prevents it from being dragged around.
+    pub fn fixed_pos(mut self, pos: impl Into<egui::Pos2>) -> Self {
+        self.window_fixed_pos = Some(pos.into());
         self
     }
 
@@ -386,6 +404,14 @@ impl FileDialog {
 
         if let Some(id) = self.window_id {
             window = window.id(id);
+        }
+
+        if let Some(pos) = self.window_default_pos {
+            window = window.default_pos(pos);
+        }
+
+        if let Some(pos) = self.window_fixed_pos {
+            window = window.fixed_pos(pos);
         }
 
         if let Some((anchor, offset)) = self.window_anchor {


### PR DESCRIPTION
- Added `FileDialog::fixed_pos` to set the window to a fixed position
- Added `FileDialog::default_pos` to set the default position of the window
- Removed anchor from sandbox example