### PR TITLE
Updated docs badge to use shields.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### 📚 Documentation
 - Fix syntax highlighting on crates.io [#9](https://github.com/fluxxcode/egui-file-dialog/pull/9)
 - Added dependency badge to `README.md` [#10](https://github.com/fluxxcode/egui-file-dialog/pull/10)
+- Updated docs badge to use shields.io [#19](https://github.com/fluxxcode/egui-file-dialog/pull/19)
 
 ## 2024-02-03 - v0.1.0
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # egui-file-dialog
 [![Latest version](https://img.shields.io/crates/v/egui-file-dialog.svg)](https://crates.io/crates/egui-file-dialog)
-[![Documentation](https://docs.rs/egui-file-dialog/badge.svg)](https://docs.rs/egui-file-dialog)
+![Documentation](https://img.shields.io/docsrs/egui-file-dialog)
 [![Dependency status](https://deps.rs/repo/github/fluxxcode/egui-file-dialog/status.svg)](https://deps.rs/repo/github/fluxxcode/egui-file-dialog)
 [![MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/fluxxcode/egui-file-dialog/blob/master/LICENSE)
 


### PR DESCRIPTION
Updated docs badge to use shields.io instead of docs.rs.

I adjusted this because I noticed that docs.rs no longer offers badges: https://docs.rs/about/badges