### PR TITLE
Fix link of docs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # egui-file-dialog
 [![Latest version](https://img.shields.io/crates/v/egui-file-dialog.svg)](https://crates.io/crates/egui-file-dialog)
-![Documentation](https://img.shields.io/docsrs/egui-file-dialog)
+[![Documentation](https://img.shields.io/docsrs/egui-file-dialog)](https://docs.rs/egui-file-dialog)
 [![Dependency status](https://deps.rs/repo/github/fluxxcode/egui-file-dialog/status.svg)](https://deps.rs/repo/github/fluxxcode/egui-file-dialog)
 [![MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/fluxxcode/egui-file-dialog/blob/master/LICENSE)
 


### PR DESCRIPTION
Forgot to set that the docs badge links to docs.rs ._.