### PR TITLE
Fix typos in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # egui-file-dialog changelog
 
+## Unreleased
+### 📚 Documentation
+- Fix typos in the documentation [#29](https://github.com/fluxxcode/egui-file-dialog/pull/29)
+
 ## 2024-02-07 - v0.2.0 - API improvements
 ### 🚨 Breaking Changes
 - Rename `FileDialog::default_window_size` to `FileDialog::default_size` [#14](https://github.com/fluxxcode/egui-file-dialog/pull/14)

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -308,7 +308,7 @@ impl FileDialog {
     /// # Examples
     ///
     /// The following example shows how the dialog can be used for multiple
-    /// actions using the `operation_id``.
+    /// actions using the `operation_id`.
     ///
     /// ```
     /// use std::path::PathBuf;
@@ -441,7 +441,7 @@ impl FileDialog {
 
     /// Returns the ID of the operation for which the dialog is currently being used.
     ///
-    /// See `FileDialog::open` more information.
+    /// See `FileDialog::open` for more information.
     pub fn operation_id(&self) -> Option<&str> {
         self.operation_id.as_deref()
     }


### PR DESCRIPTION
Fixed two typos in the documentation.