### PR TITLE
Fix eframe version in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### 📚 Documentation
 - Fix typos in the documentation [#29](https://github.com/fluxxcode/egui-file-dialog/pull/29)
+- Fix eframe version in the example in README.md [#30](https://github.com/fluxxcode/egui-file-dialog/pull/30)
 
 ## 2024-02-07 - v0.2.0 - API improvements
 ### 🚨 Breaking Changes

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following example shows the basic use of the file dialog with [eframe](https
 Cargo.toml:
 ```toml
 [dependencies]
-eframe = "0.25.0"
+eframe = "0.26.0"
 egui-file-dialog = "0.2.0"
 ```
 


### PR DESCRIPTION
When updating egui I forgot to increase the eframe version in the example in the README.md.