### PR TITLE
Improve bottom panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # egui-file-dialog changelog
 
 ## Unreleased
+### 🖥 UI
+- Improve dialog resizing [#32](https://github.com/fluxxcode/egui-file-dialog/pull/32)
+  - Error when saving a file is now displayed as a tooltip when hovering over the save button
+  - Updated file name input to use all available space
+  - Added scroll area around the selected item
+  - The default minimum window size has been further reduced
+- Added an error icon before the error message when creating a folder [#32](https://github.com/fluxxcode/egui-file-dialog/pull/32)
 ### 📚 Documentation
 - Fix typos in the documentation [#29](https://github.com/fluxxcode/egui-file-dialog/pull/29)
 - Fix eframe version in the example in README.md [#30](https://github.com/fluxxcode/egui-file-dialog/pull/30)

--- a/src/create_directory_dialog.rs
+++ b/src/create_directory_dialog.rs
@@ -113,12 +113,14 @@ impl CreateDirectoryDialog {
         if let Some(err) = &self.error {
             ui.add_space(5.0);
 
-            let response = ui.horizontal_wrapped(|ui| {
-                ui.spacing_mut().item_spacing.x = 0.0;
+            let response = ui
+                .horizontal_wrapped(|ui| {
+                    ui.spacing_mut().item_spacing.x = 0.0;
 
-                ui.colored_label(ui.style().visuals.error_fg_color, "⚠ ");
-                ui.label(err);
-            }).response;
+                    ui.colored_label(ui.style().visuals.error_fg_color, "⚠ ");
+                    ui.label(err);
+                })
+                .response;
 
             if self.scroll_to_error {
                 response.scroll_to_me(Some(egui::Align::Center));

--- a/src/create_directory_dialog.rs
+++ b/src/create_directory_dialog.rs
@@ -112,7 +112,13 @@ impl CreateDirectoryDialog {
 
         if let Some(err) = &self.error {
             ui.add_space(5.0);
-            let response = ui.label(err);
+
+            let response = ui.horizontal_wrapped(|ui| {
+                ui.spacing_mut().item_spacing.x = 0.0;
+
+                ui.colored_label(ui.style().visuals.error_fg_color, "⚠ ");
+                ui.label(err);
+            }).response;
 
             if self.scroll_to_error {
                 response.scroll_to_me(Some(egui::Align::Center));

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -178,7 +178,7 @@ impl FileDialog {
             window_fixed_pos: None,
             window_default_size: egui::Vec2::new(650.0, 370.0),
             window_max_size: None,
-            window_min_size: egui::Vec2::new(340.0, 200.0),
+            window_min_size: egui::Vec2::new(340.0, 170.0),
             window_anchor: None,
             window_resizable: true,
             window_movable: true,

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -178,7 +178,7 @@ impl FileDialog {
             window_fixed_pos: None,
             window_default_size: egui::Vec2::new(650.0, 370.0),
             window_max_size: None,
-            window_min_size: egui::Vec2::new(355.0, 200.0),
+            window_min_size: egui::Vec2::new(340.0, 200.0),
             window_anchor: None,
             window_resizable: true,
             window_movable: true,
@@ -704,7 +704,18 @@ impl FileDialog {
                 DialogMode::SelectDirectory | DialogMode::SelectFile => {
                     if self.is_selection_valid() {
                         if let Some(x) = &self.selected_item {
-                            ui.colored_label(ui.style().visuals.selection.bg_fill, x.file_name());
+                            use egui::containers::scroll_area::ScrollBarVisibility;
+
+                            egui::containers::ScrollArea::horizontal()
+                                .auto_shrink([false, false])
+                                .stick_to_right(true)
+                                .scroll_bar_visibility(ScrollBarVisibility::AlwaysHidden)
+                                .show(ui, |ui| {
+                                    ui.colored_label(
+                                        ui.style().visuals.selection.bg_fill,
+                                        x.file_name(),
+                                    );
+                                });
                         }
                     }
                 }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -970,7 +970,7 @@ impl FileDialog {
         let mut clicked = false;
 
         ui.add_enabled_ui(enabled, |ui| {
-            let response= ui.add_sized(size, egui::Button::new(label));
+            let response = ui.add_sized(size, egui::Button::new(label));
             clicked = response.clicked();
 
             if let Some(err) = err_tooltip {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -698,31 +698,7 @@ impl FileDialog {
             match &self.mode {
                 DialogMode::SelectDirectory => ui.label("Selected directory:"),
                 DialogMode::SelectFile => ui.label("Selected file:"),
-                DialogMode::SaveFile => {
-                    let response = ui.label("File name:");
-
-                    if let Some(err) = &self.file_name_input_error {
-                        // TODO: Draw tooltip above the input in the center, not below
-                        // To calc the width:
-                        // let width = ui.fonts(|f|f.glyph_width(&TextStyle::Body.resolve(ui.style()), ' '));
-                        // ui.spacing_mut().item_spacing.x = width;
-                        egui::containers::show_tooltip_for(
-                            ui.ctx(),
-                            response.id.with("__tooltip"),
-                            &response.rect.expand2(egui::Vec2::new(-15.0, 5.0)),
-                            |ui| {
-                                ui.horizontal_wrapped(|ui| {
-                                    ui.spacing_mut().item_spacing.x = 0.0;
-
-                                    ui.colored_label(ctx.style().visuals.error_fg_color, "⚠ ");
-                                    ui.label(err);
-                                })
-                            },
-                        );
-                    }
-
-                    response
-                }
+                DialogMode::SaveFile => ui.label("File name:"),
             };
 
             match &self.mode {
@@ -752,6 +728,30 @@ impl FileDialog {
 
                     if response.changed() {
                         self.file_name_input_error = self.validate_file_name_input();
+                    }
+
+                    if let Some(err) = &self.file_name_input_error {
+                        let mut pos = response.rect.min;
+
+                        // TODO: Dynamically calc position based on the tooltip size
+                        // To calc the width:
+                        // let width = ui.fonts(|f|f.glyph_width(&TextStyle::Body.resolve(ui.style()), ' '));
+                        // ui.spacing_mut().item_spacing.x = width;
+                        pos.y -= 35.0;
+
+                        egui::containers::show_tooltip_at(
+                            ui.ctx(),
+                            response.id.with("__tooltip"),
+                            Some(pos),
+                            |ui| {
+                                ui.horizontal_wrapped(|ui| {
+                                    ui.spacing_mut().item_spacing.x = 0.0;
+
+                                    ui.colored_label(ctx.style().visuals.error_fg_color, "⚠ ");
+                                    ui.label(err);
+                                })
+                            },
+                        );
                     }
                 }
             };


### PR DESCRIPTION
- Updated the bottom panel so that the dialog can also be resized in `DialogMode::SaveFile` or when selecting a file/directory with a long name
   - Here it was necessary to display the error when saving a file as a tooltip when you hover over the grayed out save button.
   ![Screenshot_20240218_172006](https://github.com/fluxxcode/egui-file-dialog/assets/55352293/002791a9-c6b1-4e12-a0bc-6d41e6b411e2)
   - Updated file name input that all available space is used
   - Added scroll area around the selected item, so that long file or folder names can be displayed without making the dialog larger. 

- The default minimum window size has been further reduced from `(355.0, 200.0)` to `(340.0, 170.0)`
- Added an error icon before the error message when creating a folder. 
![Screenshot_20240218_172105](https://github.com/fluxxcode/egui-file-dialog/assets/55352293/fa4acc59-1297-4d59-bfd6-277d50584cc6)

