### PR TITLE
Fix shortcut directories can not be selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # egui-file-dialog changelog
 
+## [Unreleased] - v0.3.1 - Bug fixes
+### 🐛 Bug Fixes
+- Fixed not being able to select a shortcut directory like Home or Documents [#43](https://github.com/fluxxcode/egui-file-dialog/pull/43)
+
 ## 2024-02-18 - v0.3.0 - UI improvements
 ### 🖥 UI
 - Updated bottom panel so that the dialog can also be resized in `DialogMode::SaveFile` or when selecting a file or directory with a long name [#32](https://github.com/fluxxcode/egui-file-dialog/pull/32)

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1195,6 +1195,8 @@ impl FileDialog {
     /// Loads the given directory and updates the `directory_stack`.
     /// The function deletes all directories from the `directory_stack` that are currently
     /// stored in the vector before the `directory_offset`.
+    ///
+    /// The function also sets the loaded directory as the selected item.
     fn load_directory(&mut self, path: &Path) -> io::Result<()> {
         let full_path = match fs::canonicalize(path) {
             Ok(path) => path,
@@ -1220,7 +1222,12 @@ impl FileDialog {
         self.directory_stack.push(full_path);
         self.directory_offset = 0;
 
-        self.load_directory_content(path)
+        self.load_directory_content(path)?;
+
+        let dir_entry = DirectoryEntry::from_path(path);
+        self.select_item(&dir_entry);
+
+        Ok(())
     }
 
     /// Loads the directory content of the given path.


### PR DESCRIPTION
Adjusted so that the directory that was loaded is automatically used as the selected item. \
This makes it possible to select the shortcut directories such as (Home, Documents) as well as the devices.