### PR TITLE
Fix root directories not displaying correctly

### DIFF
--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -50,7 +50,14 @@ impl DirectoryEntry {
         self.path
             .file_name()
             .and_then(|name| name.to_str())
-            .unwrap_or_default()
+            .unwrap_or_else(|| {
+                // Make sure the root directories like "/" or "C:\\" are displayed correctly
+                if self.path.iter().count() == 1 {
+                    return self.path.to_str().unwrap_or_default();
+                }
+
+                ""
+            })
     }
 }
 


### PR DESCRIPTION
The problem was that the file name in root directories like "/" was returned as an empty string. This has now been fixed so that the name is displayed correctly for root directories.