### PR TITLE
Fix display name of root directories on Windows

### DIFF
--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -51,7 +51,27 @@ impl DirectoryEntry {
             .file_name()
             .and_then(|name| name.to_str())
             .unwrap_or_else(|| {
-                // Make sure the root directories like "/" or "C:\\" are displayed correctly
+                // Make sure the root directories like ["C:", "\"] and ["\\?\C:", "\"] are
+                // displayed correctly
+                #[cfg(windows)]
+                if self.path.components().count() == 2 {
+                    let path = self
+                        .path
+                        .iter()
+                        .nth(0)
+                        .and_then(|seg| seg.to_str())
+                        .unwrap_or_default();
+
+                    // Skip path namespace prefix if present, for example: "\\?\C:"
+                    if path.contains(r"\\?\") {
+                        return path.get(4..).unwrap_or(path);
+                    }
+
+                    return path;
+                }
+
+                // Make sure the root directory "/" is displayed correctly
+                #[cfg(not(windows))]
                 if self.path.iter().count() == 1 {
                     return self.path.to_str().unwrap_or_default();
                 }


### PR DESCRIPTION
Root directories on Windows were not displayed correctly due to path namespace prefixes.

Ref: https://github.com/fluxxcode/egui-file-dialog/pull/44