### PR TITLE
Implement FileDialog::take_selected

### DIFF
--- a/examples/sandbox/src/main.rs
+++ b/examples/sandbox/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use eframe::egui;
-use egui_file_dialog::{DialogMode, DialogState, FileDialog};
+use egui_file_dialog::{DialogMode, FileDialog};
 
 struct MyApp {
     file_dialog: FileDialog,
@@ -50,14 +50,15 @@ impl eframe::App for MyApp {
             }
             ui.label(format!("File to save: {:?}", self.saved_file));
 
-            match self.file_dialog.update(ctx).state() {
-                DialogState::Selected(path) => match self.file_dialog.mode() {
+            self.file_dialog.update(ctx);
+
+            if let Some(path) = self.file_dialog.take_selected() {
+                match self.file_dialog.mode() {
                     DialogMode::SelectDirectory => self.selected_directory = Some(path),
                     DialogMode::SelectFile => self.selected_file = Some(path),
                     DialogMode::SaveFile => self.saved_file = Some(path),
-                },
-                _ => {}
-            };
+                }
+            }
         });
     }
 }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -485,6 +485,23 @@ impl FileDialog {
         }
     }
 
+    /// Returns the directory or file that the user selected, or the target file
+    /// if the dialog is in `DialogMode::SaveFile` mode.
+    /// Unlike `FileDialog::selected`, this method returns the selected path only once and
+    /// sets the dialog's state to `DialogState::Closed`.
+    ///
+    /// None is returned when the user has not yet selected an item.
+    pub fn take_selected(&mut self) -> Option<PathBuf> {
+        match &mut self.state {
+            DialogState::Selected(path) => {
+                let path = std::mem::take(path);
+                self.state = DialogState::Closed;
+                Some(path)
+            }
+            _ => None,
+        }
+    }
+
     /// Returns the ID of the operation for which the dialog is currently being used.
     ///
     /// See `FileDialog::open` for more information.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -474,16 +474,6 @@ impl FileDialog {
     // -------------------------------------------------
     // Getter:
 
-    /// Returns the mode the dialog is currently in.
-    pub fn mode(&self) -> DialogMode {
-        self.mode
-    }
-
-    /// Returns the state the dialog is currently in.
-    pub fn state(&self) -> DialogState {
-        self.state.clone()
-    }
-
     /// Returns the directory or file that the user selected, or the target file
     /// if the dialog is in `DialogMode::SaveFile` mode.
     ///
@@ -500,6 +490,16 @@ impl FileDialog {
     /// See `FileDialog::open` for more information.
     pub fn operation_id(&self) -> Option<&str> {
         self.operation_id.as_deref()
+    }
+
+    /// Returns the mode the dialog is currently in.
+    pub fn mode(&self) -> DialogMode {
+        self.mode
+    }
+
+    /// Returns the state the dialog is currently in.
+    pub fn state(&self) -> DialogState {
+        self.state.clone()
     }
 }
 


### PR DESCRIPTION
Implemented `FileDialog::take_selected`. Unlike `FileDialog::selected`, this method returns the selected path only once and sets the dialog state to `DialogState::Closed`.

Thanks [@crumblingstatue](https://github.com/crumblingstatue)!

