### PR TITLE
Implement FileDialog::show_left_panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased] - v0.4.0 - Customization
 ### ✨ Features
 - Added `FileDialog::take_selected` as an alternative to `FileDialog::selected` [#52](https://github.com/fluxxcode/egui-file-dialog/pull/52)
+- Added `FileDialog::show_left_panel` to show or hide the left panel with the shortcut directories such as “Home”, “Documents”, etc. [#54](https://github.com/fluxxcode/egui-file-dialog/pull/54)
 
 ## 2024-02-20 - v0.3.1 - Bug fixes
 ### 🐛 Bug Fixes

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -392,6 +392,12 @@ impl FileDialog {
         self
     }
 
+    /// Sets the default file name when opening the dialog in `DialogMode::SaveFile` mode.
+    pub fn default_file_name(mut self, name: &str) -> Self {
+        self.default_file_name = name.to_string();
+        self
+    }
+
     /// Overwrites the window title.
     ///
     /// By default, the title is set dynamically, based on the `DialogMode`
@@ -462,12 +468,6 @@ impl FileDialog {
     /// Sets if the title bar of the window is shown.
     pub fn title_bar(mut self, title_bar: bool) -> Self {
         self.window_title_bar = title_bar;
-        self
-    }
-
-    /// Sets the default file name when opening the dialog in `DialogMode::SaveFile` mode.
-    pub fn default_file_name(mut self, name: &str) -> Self {
-        self.default_file_name = name.to_string();
         self
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -126,6 +126,10 @@ pub struct FileDialog {
     /// If the title bar of the window is shown
     window_title_bar: bool,
 
+    /// If the sidebar with the shortcut directories such as
+    /// “Home”, “Documents” etc. should be visible.
+    show_left_panel: bool,
+
     /// The dialog that is shown when the user wants to create a new directory.
     create_directory_dialog: CreateDirectoryDialog,
 
@@ -186,6 +190,8 @@ impl FileDialog {
             window_resizable: true,
             window_movable: true,
             window_title_bar: true,
+
+            show_left_panel: true,
 
             create_directory_dialog: CreateDirectoryDialog::new(),
 
@@ -350,13 +356,15 @@ impl FileDialog {
                     self.ui_update_top_panel(ctx, ui);
                 });
 
-            egui::SidePanel::left("fe_left_panel")
-                .resizable(true)
-                .default_width(150.0)
-                .width_range(90.0..=250.0)
-                .show_inside(ui, |ui| {
-                    self.ui_update_left_panel(ctx, ui);
-                });
+            if self.show_left_panel {
+                egui::SidePanel::left("fe_left_panel")
+                    .resizable(true)
+                    .default_width(150.0)
+                    .width_range(90.0..=250.0)
+                    .show_inside(ui, |ui| {
+                        self.ui_update_left_panel(ctx, ui);
+                    });
+            }
 
             egui::TopBottomPanel::bottom("fe_bottom_panel")
                 .resizable(false)
@@ -468,6 +476,13 @@ impl FileDialog {
     /// Sets if the title bar of the window is shown.
     pub fn title_bar(mut self, title_bar: bool) -> Self {
         self.window_title_bar = title_bar;
+        self
+    }
+
+    /// Sets if the sidebar with the shortcut directories such as
+    /// “Home”, “Documents” etc. should be visible.
+    pub fn show_left_panel(mut self, show_left_panel: bool) -> Self {
+        self.show_left_panel = show_left_panel;
         self
     }
 


### PR DESCRIPTION
Implemented `FileDialog::show_left_panel` to show or hide the left panel with the shortcut directories such as “Home”, “Documents”, etc.