### PR TITLE
Implement show_top_panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### ✨ Features
 - Added `FileDialog::take_selected` as an alternative to `FileDialog::selected` [#52](https://github.com/fluxxcode/egui-file-dialog/pull/52)
 - Added `FileDialogConfig` and `FileDialog::overwrite_config` to override the configuration of a file dialog. This is useful if you want to configure multiple `FileDialog` objects with the same options. [#58](https://github.com/fluxxcode/egui-file-dialog/pull/58)
+- Added `FileDialog::show_top_panel` to show or hide the top panel with the navigation buttons, current path, etc. [#60](https://github.com/fluxxcode/egui-file-dialog/pull/60)
 - Added `FileDialog::show_left_panel` to show or hide the left panel with the shortcut directories such as “Home”, “Documents”, etc. [#54](https://github.com/fluxxcode/egui-file-dialog/pull/54)
 - Added `FileDialog::show_places`, `FileDialog::show_devices` and `FileDialog::show_removable_devices` to show or hide individual section of the left panel [#57](https://github.com/fluxxcode/egui-file-dialog/pull/57)
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -82,6 +82,10 @@ pub struct FileDialogConfig {
 
     // ------------------------------------------------------------------------
     // Feature options:
+    /// If the top panel with the navigation buttons, current path display and search input
+    /// should be visible.
+    pub show_top_panel: bool,
+
     /// If the sidebar with the shortcut directories such as
     /// “Home”, “Documents” etc. should be visible.
     pub show_left_panel: bool,
@@ -110,6 +114,8 @@ impl Default for FileDialogConfig {
             resizable: true,
             movable: true,
             title_bar: true,
+
+            show_top_panel: true,
 
             show_left_panel: true,
             show_places: true,
@@ -548,6 +554,13 @@ impl FileDialog {
         self
     }
 
+    /// Sets if the top panel with the navigation buttons, current path display
+    /// and search input should be visible.
+    pub fn show_top_panel(mut self, show_top_panel: bool) -> Self {
+        self.config.show_top_panel = show_top_panel;
+        self
+    }
+
     /// Sets if the sidebar with the shortcut directories such as
     /// “Home”, “Documents” etc. should be visible.
     pub fn show_left_panel(mut self, show_left_panel: bool) -> Self {
@@ -638,11 +651,13 @@ impl FileDialog {
         let mut is_open = true;
 
         self.create_window(&mut is_open).show(ctx, |ui| {
-            egui::TopBottomPanel::top("fe_top_panel")
-                .resizable(false)
-                .show_inside(ui, |ui| {
-                    self.ui_update_top_panel(ui);
-                });
+            if self.config.show_top_panel {
+                egui::TopBottomPanel::top("fe_top_panel")
+                    .resizable(false)
+                    .show_inside(ui, |ui| {
+                        self.ui_update_top_panel(ui);
+                    });
+            }
 
             if self.config.show_left_panel {
                 egui::SidePanel::left("fe_left_panel")


### PR DESCRIPTION
Implemented `FileDialog::show_top_panel` to show or hide the top panel with the navigation buttons, current path display etc.