### PR TITLE
Implement show_new_folder_button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 ### ✨ Features
 - Added `FileDialog::take_selected` as an alternative to `FileDialog::selected` [#52](https://github.com/fluxxcode/egui-file-dialog/pull/52)
 - Added `FileDialogConfig` and `FileDialog::overwrite_config` to override the configuration of a file dialog. This is useful if you want to configure multiple `FileDialog` objects with the same options. [#58](https://github.com/fluxxcode/egui-file-dialog/pull/58)
-- Added `FileDialog::show_top_panel` to show or hide the top panel with the navigation buttons, current path, etc. [#60](https://github.com/fluxxcode/egui-file-dialog/pull/60)
-- Added `FileDialog::show_parent_button`, `FileDialog::show_back_button` and `FileDialog::show_forward_button` to show or hide the individual navigation buttons in the top panel. [#64](https://github.com/fluxxcode/egui-file-dialog/pull/61)
-- Added `FileDialog::show_left_panel` to show or hide the left panel with the shortcut directories such as “Home”, “Documents”, etc. [#54](https://github.com/fluxxcode/egui-file-dialog/pull/54)
+#### Methods for showing or hiding certain dialog areas and functions
+- Added `FileDialog::show_top_panel` to show or hide the top panel [#60](https://github.com/fluxxcode/egui-file-dialog/pull/60)
+- Added `FileDialog::show_parent_button`, `FileDialog::show_back_button` and `FileDialog::show_forward_button` to show or hide the individual navigation buttons in the top panel. [#61](https://github.com/fluxxcode/egui-file-dialog/pull/61)
+- Added `FileDialog::show_new_folder_button` to show or hide the button to create a new folder [#62](https://github.com/fluxxcode/egui-file-dialog/pull/62)
+- Added `FileDialog::show_left_panel` to show or hide the left panel  [#54](https://github.com/fluxxcode/egui-file-dialog/pull/54)
 - Added `FileDialog::show_places`, `FileDialog::show_devices` and `FileDialog::show_removable_devices` to show or hide individual section of the left panel [#57](https://github.com/fluxxcode/egui-file-dialog/pull/57)
 
 ### 🔧 Changes

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -91,6 +91,8 @@ pub struct FileDialogConfig {
     pub show_back_button: bool,
     /// Whether the forward button should be visible at the top.
     pub show_forward_button: bool,
+    /// If the button to create a new folder should be visible at the top.
+    pub show_new_folder_button: bool,
 
     /// If the sidebar with the shortcut directories such as
     /// “Home”, “Documents” etc. should be visible.
@@ -125,6 +127,7 @@ impl Default for FileDialogConfig {
             show_parent_button: true,
             show_back_button: true,
             show_forward_button: true,
+            show_new_folder_button: true,
 
             show_left_panel: true,
             show_places: true,
@@ -594,6 +597,14 @@ impl FileDialog {
         self
     }
 
+    /// Sets whether the button to create a new folder should be visible in the top panel.
+    ///
+    /// Has no effect when `FileDialog::show_top_panel` is disabled.
+    pub fn show_new_folder_button(mut self, show_new_folder_button: bool) -> Self {
+        self.config.show_new_folder_button = show_new_folder_button;
+        self
+    }
+
     /// Sets if the sidebar with the shortcut directories such as
     /// “Home”, “Documents” etc. should be visible.
     pub fn show_left_panel(mut self, show_left_panel: bool) -> Self {
@@ -807,13 +818,15 @@ impl FileDialog {
             let _ = self.load_next_directory();
         }
 
-        if self.ui_button_sized(
-            ui,
-            !self.create_directory_dialog.is_open(),
-            *button_size,
-            "+",
-            None,
-        ) {
+        if self.config.show_new_folder_button
+            && self.ui_button_sized(
+                ui,
+                !self.create_directory_dialog.is_open(),
+                *button_size,
+                "+",
+                None,
+            )
+        {
             if let Some(x) = self.current_directory() {
                 self.create_directory_dialog.open(x.to_path_buf());
             }


### PR DESCRIPTION
Implemented `FileDialog::show_new_folder_button` to show or hide the button to create a new folder.