### PR TITLE
Implement show_reload_button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `FileDialog::show_parent_button`, `FileDialog::show_back_button` and `FileDialog::show_forward_button` to show or hide the individual navigation buttons in the top panel. [#61](https://github.com/fluxxcode/egui-file-dialog/pull/61)
 - Added `FileDialog::show_new_folder_button` to show or hide the button to create a new folder [#62](https://github.com/fluxxcode/egui-file-dialog/pull/62)
 - Added `FileDialog::show_current_path` to show or hide the current path in the top panel [#63](https://github.com/fluxxcode/egui-file-dialog/pull/63)
+- Added `FileDialog::show_reload_button` to show or hide the reload button in the top panel [#64](https://github.com/fluxxcode/egui-file-dialog/pull/64)
 - Added `FileDialog::show_left_panel` to show or hide the left panel  [#54](https://github.com/fluxxcode/egui-file-dialog/pull/54)
 - Added `FileDialog::show_places`, `FileDialog::show_devices` and `FileDialog::show_removable_devices` to show or hide individual section of the left panel [#57](https://github.com/fluxxcode/egui-file-dialog/pull/57)
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -95,6 +95,8 @@ pub struct FileDialogConfig {
     pub show_new_folder_button: bool,
     /// If the current path display in the top panel should be visible.
     pub show_current_path: bool,
+    /// If the reload button in the top panel should be visible.
+    pub show_reload_button: bool,
 
     /// If the sidebar with the shortcut directories such as
     /// “Home”, “Documents” etc. should be visible.
@@ -131,6 +133,7 @@ impl Default for FileDialogConfig {
             show_forward_button: true,
             show_new_folder_button: true,
             show_current_path: true,
+            show_reload_button: true,
 
             show_left_panel: true,
             show_places: true,
@@ -616,6 +619,14 @@ impl FileDialog {
         self
     }
 
+    /// Sets whether the reload button should be visible in the top panel.
+    ///
+    /// Has no effect when `FileDialog::show_top_panel` is disabled.
+    pub fn show_reload_button(mut self, show_reload_button: bool) -> Self {
+        self.config.show_reload_button = show_reload_button;
+        self
+    }
+
     /// Sets if the sidebar with the shortcut directories such as
     /// “Home”, “Documents” etc. should be visible.
     pub fn show_left_panel(mut self, show_left_panel: bool) -> Self {
@@ -791,7 +802,9 @@ impl FileDialog {
             }
 
             // Reload button
-            if ui.add_sized(BUTTON_SIZE, egui::Button::new("⟲")).clicked() {
+            if self.config.show_reload_button
+                && ui.add_sized(BUTTON_SIZE, egui::Button::new("⟲")).clicked()
+            {
                 self.refresh();
             }
 


### PR DESCRIPTION
Implemented `FileDialog::show_reload_button` to show or hide the reload button in the top panel.