### PR TITLE
Implement directory_separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### ✨ Features
 - Added `FileDialog::take_selected` as an alternative to `FileDialog::selected` [#52](https://github.com/fluxxcode/egui-file-dialog/pull/52)
 - Added `FileDialogConfig`, `FileDialog::with_config` and `FileDialog::overwrite_config` to set and override the configuration of a file dialog. This is useful if you want to configure multiple `FileDialog` objects with the same options. [#58](https://github.com/fluxxcode/egui-file-dialog/pull/58) and [#67](https://github.com/fluxxcode/egui-file-dialog/pull/67)
+- Added `FileDialog::directory_separator` to overwrite the directory separator that is used when displaying the current path [#68](https://github.com/fluxxcode/egui-file-dialog/pull/68)
+
 #### Methods for showing or hiding certain dialog areas and functions
 - Added `FileDialog::show_top_panel` to show or hide the top panel [#60](https://github.com/fluxxcode/egui-file-dialog/pull/60)
 - Added `FileDialog::show_parent_button`, `FileDialog::show_back_button` and `FileDialog::show_forward_button` to show or hide the individual navigation buttons in the top panel. [#61](https://github.com/fluxxcode/egui-file-dialog/pull/61)

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,9 @@ pub struct FileDialogConfig {
     pub initial_directory: PathBuf,
     /// The default filename when opening the dialog in `DialogMode::SaveFile` mode.
     pub default_file_name: String,
+    /// Sets the separator of the directories when displaying a path.
+    /// Currently only used when the current path is displayed in the top panel.
+    pub directory_separator: String,
 
     // ------------------------------------------------------------------------
     // Window options:
@@ -83,6 +86,7 @@ impl Default for FileDialogConfig {
         Self {
             initial_directory: std::env::current_dir().unwrap_or_default(),
             default_file_name: String::new(),
+            directory_separator: String::from(">"),
 
             title: None,
             id: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+#![warn(missing_docs)] // Let's keep the public API well documented!
+
 use std::path::PathBuf;
 
 /// Contains configuration values of a file dialog.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -400,6 +400,13 @@ impl FileDialog {
         self
     }
 
+    /// Sets the separator of the directories when displaying a path.
+    /// Currently only used when the current path is displayed in the top panel.
+    pub fn directory_separator(mut self, separator: &str) -> Self {
+        self.config.directory_separator = separator.to_string();
+        self
+    }
+
     /// Overwrites the window title.
     ///
     /// By default, the title is set dynamically, based on the `DialogMode`
@@ -829,7 +836,7 @@ impl FileDialog {
                                         if i == 1 && segment == "\\" {
                                             file_name = drive_letter.as_str();
                                         } else if i != 0 {
-                                            ui.label(">");
+                                            ui.label(self.config.directory_separator.as_str());
                                         }
                                     }
 
@@ -838,7 +845,7 @@ impl FileDialog {
 
                                     #[cfg(not(windows))]
                                     if i != 0 {
-                                        ui.label(">");
+                                        ui.label(self.config.directory_separator.as_str());
                                     }
 
                                     if ui.button(file_name).clicked() {


### PR DESCRIPTION
Implemented `FileDialog::directory_separator` to overwrite the directory separator that is used when displaying the current path.