### PR TITLE
Implement FileDialogLabels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### ✨ Features
 - Added `FileDialog::take_selected` as an alternative to `FileDialog::selected` [#52](https://github.com/fluxxcode/egui-file-dialog/pull/52)
 - Added `FileDialogConfig`, `FileDialog::with_config` and `FileDialog::overwrite_config` to set and override the configuration of a file dialog. This is useful if you want to configure multiple `FileDialog` objects with the same options. [#58](https://github.com/fluxxcode/egui-file-dialog/pull/58) and [#67](https://github.com/fluxxcode/egui-file-dialog/pull/67)
+- Added `FileDialogLabels` and `FileDialog::labels` to enable multiple language support [#69](https://github.com/fluxxcode/egui-file-dialog/pull/69)
 - Added `FileDialog::directory_separator` to overwrite the directory separator that is used when displaying the current path [#68](https://github.com/fluxxcode/egui-file-dialog/pull/68)
 
 #### Methods for showing or hiding certain dialog areas and functions

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,8 +129,20 @@ impl Default for FileDialogConfig {
 ///
 /// # Example
 ///
+/// The following example shows how the default title of the dialog can be displayed
+/// in German instead of English.
+///
 /// ```
-/// todo!("Example!");
+/// use egui_file_dialog::{FileDialog, FileDialogLabels};
+///
+/// let labels_german = FileDialogLabels {
+///     title_select_directory: "📁 Ordner Öffnen".to_string(),
+///     title_select_file: "📂 Datei Öffnen".to_string(),
+///     title_save_file: "📥 Datei Speichern".to_string(),
+///     ..Default::default()
+/// };
+///
+/// let file_dialog = FileDialog::new().labels(labels_german);
 /// ````
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FileDialogLabels {

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ use std::path::PathBuf;
 pub struct FileDialogConfig {
     // ------------------------------------------------------------------------
     // General options:
+    /// The labels that the dialog uses.
+    pub labels: FileDialogLabels,
     /// The first directory that will be opened when the dialog opens.
     pub initial_directory: PathBuf,
     /// The default filename when opening the dialog in `DialogMode::SaveFile` mode.
@@ -84,8 +86,10 @@ pub struct FileDialogConfig {
 }
 
 impl Default for FileDialogConfig {
+    /// Creates a new configuration with default values
     fn default() -> Self {
         Self {
+            labels: FileDialogLabels::default(),
             initial_directory: std::env::current_dir().unwrap_or_default(),
             default_file_name: String::new(),
             directory_separator: String::from(">"),
@@ -115,6 +119,114 @@ impl Default for FileDialogConfig {
             show_places: true,
             show_devices: true,
             show_removable_devices: true,
+        }
+    }
+}
+
+/// Contains the text labels that the file dialog uses.
+///
+/// This is used to enable multiple language support.
+///
+/// # Example
+///
+/// ```
+/// todo!("Example!");
+/// ````
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct FileDialogLabels {
+    // ------------------------------------------------------------------------
+    // General:
+    /// The default window title used when the dialog is in `DialogMode::SelectDirectory` mode.
+    pub title_select_directory: String,
+    /// The default window title used when the dialog is in `DialogMode::SelectFile` mode.
+    pub title_select_file: String,
+    /// The default window title used when the dialog is in `DialogMode::SaveFile` mode.
+    pub title_save_file: String,
+
+    // ------------------------------------------------------------------------
+    // Left panel:
+    /// Heading of the "Places" section in the left panel
+    pub heading_places: String,
+    /// Heading of the "Devices" section in the left panel
+    pub heading_devices: String,
+    /// Heading of the "Removable Devices" section in the left panel
+    pub heading_removable_devices: String,
+
+    /// Name of the home directory
+    pub home_dir: String,
+    /// Name of the desktop directory
+    pub desktop_dir: String,
+    /// Name of the documents directory
+    pub documents_dir: String,
+    /// Name of the downloads directory
+    pub downloads_dir: String,
+    /// Name of the audio directory
+    pub audio_dir: String,
+    /// Name of the pictures directory
+    pub pictures_dir: String,
+    /// Name of the videos directory
+    pub videos_dir: String,
+
+    // ------------------------------------------------------------------------
+    // Bottom panel:
+    /// Text that appears in front of the selected folder preview in the bottom panel.
+    pub selected_directory: String,
+    /// Text that appears in front of the selected file preview in the bottom panel.
+    pub selected_file: String,
+    /// Text that appears in front of the file name input in the bottom panel.
+    pub file_name: String,
+
+    /// Button text to open the selected item.
+    pub open_button: String,
+    /// Button text to save the file.
+    pub save_button: String,
+    /// Button text to cancel the dialog.
+    pub cancel_button: String,
+
+    // ------------------------------------------------------------------------
+    // Error message:
+    /// Error if no folder name was specified.
+    pub err_empty_folder_name: String,
+    /// Error if no file name was specified.
+    pub err_empty_file_name: String,
+    /// Error if the directory already exists.
+    pub err_directory_exists: String,
+    /// Error if the file already exists.
+    pub err_file_exists: String,
+}
+
+impl Default for FileDialogLabels {
+    /// Creates a new object with the default english labels.
+    fn default() -> Self {
+        Self {
+            title_select_directory: "📁 Select Folder".to_string(),
+            title_select_file: "📂 Open File".to_string(),
+            title_save_file: "📥 Save File".to_string(),
+
+            heading_places: "Places".to_string(),
+            heading_devices: "Devices".to_string(),
+            heading_removable_devices: "Removable Devices".to_string(),
+
+            home_dir: "🏠  Home".to_string(),
+            desktop_dir: "🖵  Desktop".to_string(),
+            documents_dir: "🗐  Documents".to_string(),
+            downloads_dir: "📥  Downloads".to_string(),
+            audio_dir: "🎵  Audio".to_string(),
+            pictures_dir: "🖼  Pictures".to_string(),
+            videos_dir: "🎞  Videos".to_string(),
+
+            selected_directory: "Selected directory:".to_string(),
+            selected_file: "Selected file:".to_string(),
+            file_name: "File name:".to_string(),
+
+            open_button: "🗀  Open".to_string(),
+            save_button: "📥  Save".to_string(),
+            cancel_button: "🚫 Cancel".to_string(),
+
+            err_empty_folder_name: "Name of the folder cannot be empty".to_string(),
+            err_empty_file_name: "The file name cannot be empty".to_string(),
+            err_directory_exists: "A directory with the name already exists".to_string(),
+            err_file_exists: "A file with the name already exists".to_string(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,7 +143,7 @@ impl Default for FileDialogConfig {
 /// };
 ///
 /// let file_dialog = FileDialog::new().labels(labels_german);
-/// ````
+/// ```
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FileDialogLabels {
     // ------------------------------------------------------------------------

--- a/src/create_directory_dialog.rs
+++ b/src/create_directory_dialog.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::FileDialogLabels;
+
 pub struct CreateDirectoryResponse {
     /// Contains the path to the directory that was created.
     directory: Option<PathBuf>,
@@ -74,7 +76,11 @@ impl CreateDirectoryDialog {
 
     /// Main update function of the dialog. Should be called in every frame
     /// in which the dialog is to be displayed.
-    pub fn update(&mut self, ui: &mut egui::Ui) -> CreateDirectoryResponse {
+    pub fn update(
+        &mut self,
+        ui: &mut egui::Ui,
+        labels: &FileDialogLabels,
+    ) -> CreateDirectoryResponse {
         if !self.open {
             return CreateDirectoryResponse::new_empty();
         }
@@ -90,12 +96,12 @@ impl CreateDirectoryDialog {
                 response.scroll_to_me(Some(egui::Align::Center));
                 response.request_focus();
 
-                self.error = self.validate_input();
+                self.error = self.validate_input(labels);
                 self.init = false;
             }
 
             if response.changed() {
-                self.error = self.validate_input();
+                self.error = self.validate_input(labels);
             }
 
             if ui
@@ -165,19 +171,19 @@ impl CreateDirectoryDialog {
 
     /// Validates the folder name input.
     /// Returns None if the name is valid. Otherwise returns the error message.
-    fn validate_input(&mut self) -> Option<String> {
+    fn validate_input(&mut self, labels: &FileDialogLabels) -> Option<String> {
         if self.input.is_empty() {
-            return self.create_error("Name of the folder can not be empty");
+            return self.create_error(&labels.err_empty_file_name);
         }
 
         if let Some(mut x) = self.directory.clone() {
             x.push(self.input.as_str());
 
             if x.is_dir() {
-                return self.create_error("A directory with the name already exists");
+                return self.create_error(&labels.err_directory_exists);
             }
             if x.is_file() {
-                return self.create_error("A file with the name already exists");
+                return self.create_error(&labels.err_file_exists);
             }
         } else {
             // This error should not occur because the validate_input function is only

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-use crate::config::FileDialogConfig;
+use crate::config::{FileDialogConfig, FileDialogLabels};
 use crate::create_directory_dialog::CreateDirectoryDialog;
 use crate::data::{DirectoryContent, DirectoryEntry, Disk, Disks, UserDirectories};
 
@@ -265,9 +265,9 @@ impl FileDialog {
             self.window_title = title.clone();
         } else {
             self.window_title = match mode {
-                DialogMode::SelectDirectory => "📁 Select Folder".to_string(),
-                DialogMode::SelectFile => "📂 Open File".to_string(),
-                DialogMode::SaveFile => "📥 Save File".to_string(),
+                DialogMode::SelectDirectory => self.config.labels.title_select_directory.clone(),
+                DialogMode::SelectFile => self.config.labels.title_select_file.clone(),
+                DialogMode::SaveFile => self.config.labels.title_save_file.clone(),
             };
         }
 
@@ -379,6 +379,16 @@ impl FileDialog {
     /// ```
     pub fn overwrite_config(mut self, config: FileDialogConfig) -> Self {
         self.config = config;
+        self
+    }
+
+    /// Sets the labels the file dialog uses.
+    ///
+    /// Used to enable multiple language support.
+    ///
+    /// See `FileDialogLabels` for more information.
+    pub fn labels(mut self, labels: FileDialogLabels) -> Self {
+        self.config.labels = labels;
         self
     }
 
@@ -918,11 +928,14 @@ impl FileDialog {
     fn ui_update_user_directories(&mut self, ui: &mut egui::Ui, spacing: f32) -> bool {
         if let Some(dirs) = self.user_directories.clone() {
             ui.add_space(spacing);
-            ui.label("Places");
+            ui.label(self.config.labels.heading_places.as_str());
 
             if let Some(path) = dirs.home_dir() {
                 if ui
-                    .selectable_label(self.current_directory() == Some(path), "🏠  Home")
+                    .selectable_label(
+                        self.current_directory() == Some(path),
+                        self.config.labels.home_dir.as_str(),
+                    )
                     .clicked()
                 {
                     let _ = self.load_directory(path);
@@ -931,7 +944,10 @@ impl FileDialog {
 
             if let Some(path) = dirs.desktop_dir() {
                 if ui
-                    .selectable_label(self.current_directory() == Some(path), "🖵  Desktop")
+                    .selectable_label(
+                        self.current_directory() == Some(path),
+                        self.config.labels.desktop_dir.as_str(),
+                    )
                     .clicked()
                 {
                     let _ = self.load_directory(path);
@@ -939,7 +955,10 @@ impl FileDialog {
             }
             if let Some(path) = dirs.document_dir() {
                 if ui
-                    .selectable_label(self.current_directory() == Some(path), "🗐  Documents")
+                    .selectable_label(
+                        self.current_directory() == Some(path),
+                        self.config.labels.documents_dir.as_str(),
+                    )
                     .clicked()
                 {
                     let _ = self.load_directory(path);
@@ -947,7 +966,10 @@ impl FileDialog {
             }
             if let Some(path) = dirs.download_dir() {
                 if ui
-                    .selectable_label(self.current_directory() == Some(path), "📥  Downloads")
+                    .selectable_label(
+                        self.current_directory() == Some(path),
+                        self.config.labels.downloads_dir.as_str(),
+                    )
                     .clicked()
                 {
                     let _ = self.load_directory(path);
@@ -955,7 +977,10 @@ impl FileDialog {
             }
             if let Some(path) = dirs.audio_dir() {
                 if ui
-                    .selectable_label(self.current_directory() == Some(path), "🎵  Audio")
+                    .selectable_label(
+                        self.current_directory() == Some(path),
+                        self.config.labels.audio_dir.as_str(),
+                    )
                     .clicked()
                 {
                     let _ = self.load_directory(path);
@@ -963,7 +988,10 @@ impl FileDialog {
             }
             if let Some(path) = dirs.picture_dir() {
                 if ui
-                    .selectable_label(self.current_directory() == Some(path), "🖼  Pictures")
+                    .selectable_label(
+                        self.current_directory() == Some(path),
+                        self.config.labels.pictures_dir.as_str(),
+                    )
                     .clicked()
                 {
                     let _ = self.load_directory(path);
@@ -971,7 +999,10 @@ impl FileDialog {
             }
             if let Some(path) = dirs.video_dir() {
                 if ui
-                    .selectable_label(self.current_directory() == Some(path), "🎞  Videos")
+                    .selectable_label(
+                        self.current_directory() == Some(path),
+                        self.config.labels.videos_dir.as_str(),
+                    )
                     .clicked()
                 {
                     let _ = self.load_directory(path);
@@ -994,7 +1025,7 @@ impl FileDialog {
         for (i, disk) in disks.iter().filter(|x| !x.is_removable()).enumerate() {
             if i == 0 {
                 ui.add_space(spacing);
-                ui.label("Devices");
+                ui.label(self.config.labels.heading_devices.as_str());
 
                 visible = true;
             }
@@ -1020,7 +1051,7 @@ impl FileDialog {
         for (i, disk) in disks.iter().filter(|x| x.is_removable()).enumerate() {
             if i == 0 {
                 ui.add_space(spacing);
-                ui.label("Removable Devices");
+                ui.label(self.config.labels.heading_removable_devices.as_str());
 
                 visible = true;
             }
@@ -1060,9 +1091,11 @@ impl FileDialog {
     fn ui_update_selection_preview(&mut self, ui: &mut egui::Ui) {
         ui.horizontal(|ui| {
             match &self.mode {
-                DialogMode::SelectDirectory => ui.label("Selected directory:"),
-                DialogMode::SelectFile => ui.label("Selected file:"),
-                DialogMode::SaveFile => ui.label("File name:"),
+                DialogMode::SelectDirectory => {
+                    ui.label(self.config.labels.selected_directory.as_str())
+                }
+                DialogMode::SelectFile => ui.label(self.config.labels.selected_file.as_str()),
+                DialogMode::SaveFile => ui.label(self.config.labels.file_name.as_str()),
             };
 
             match &self.mode {
@@ -1104,8 +1137,10 @@ impl FileDialog {
 
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
             let label = match &self.mode {
-                DialogMode::SelectDirectory | DialogMode::SelectFile => "🗀  Open",
-                DialogMode::SaveFile => "📥  Save",
+                DialogMode::SelectDirectory | DialogMode::SelectFile => {
+                    self.config.labels.open_button.as_str()
+                }
+                DialogMode::SaveFile => self.config.labels.save_button.as_str(),
             };
 
             if self.ui_button_sized(
@@ -1144,7 +1179,10 @@ impl FileDialog {
             ui.add_space(ui.ctx().style().spacing.item_spacing.y);
 
             if ui
-                .add_sized(BUTTON_SIZE, egui::Button::new("🚫 Cancel"))
+                .add_sized(
+                    BUTTON_SIZE,
+                    egui::Button::new(self.config.labels.cancel_button.as_str()),
+                )
                 .clicked()
             {
                 self.cancel();
@@ -1228,7 +1266,11 @@ impl FileDialog {
                     self.scroll_to_selection = false;
                     self.directory_content = data;
 
-                    if let Some(path) = self.create_directory_dialog.update(ui).directory() {
+                    if let Some(path) = self
+                        .create_directory_dialog
+                        .update(ui, &self.config.labels)
+                        .directory()
+                    {
                         let entry = DirectoryEntry::from_path(&path);
 
                         self.directory_content.push(entry.clone());
@@ -1344,7 +1386,7 @@ impl FileDialog {
     /// Returns None if the file name is valid. Otherwise returns an error message.
     fn validate_file_name_input(&self) -> Option<String> {
         if self.file_name_input.is_empty() {
-            return Some("The file name cannot be empty".to_string());
+            return Some(self.config.labels.err_empty_file_name.clone());
         }
 
         if let Some(x) = self.current_directory() {
@@ -1352,10 +1394,10 @@ impl FileDialog {
             full_path.push(self.file_name_input.as_str());
 
             if full_path.is_dir() {
-                return Some("A directory with the name already exists".to_string());
+                return Some(self.config.labels.err_directory_exists.clone());
             }
             if full_path.is_file() {
-                return Some("A file with the name already exists".to_string());
+                return Some(self.config.labels.err_file_exists.clone());
             }
         } else {
             // There is most likely a bug in the code if we get this error message!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,5 +58,5 @@ mod create_directory_dialog;
 mod data;
 mod file_dialog;
 
-pub use config::FileDialogConfig;
+pub use config::{FileDialogConfig, FileDialogLabels};
 pub use file_dialog::{DialogMode, DialogState, FileDialog};


### PR DESCRIPTION
Implemented `FileDialogLabels` and `FileDialog::labels` to enable multiple language support.

The following example shows how the default title of the dialog can be displayed in German instead of English.

```rust
use egui_file_dialog::{FileDialog, FileDialogLabels};

let labels_german = FileDialogLabels {
    title_select_directory: "📁 Ordner Öffnen".to_string(),
    title_select_file: "📂 Datei Öffnen".to_string(),
    title_save_file: "📥 Datei Speichern".to_string(),
    ..Default::default()
 };

let file_dialog = FileDialog::new().labels(labels_german);
```

