### PR TITLE
Implement err_icon, folder_icon and file_icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `FileDialogConfig`, `FileDialog::with_config` and `FileDialog::overwrite_config` to set and override the configuration of a file dialog. This is useful if you want to configure multiple `FileDialog` objects with the same options. [#58](https://github.com/fluxxcode/egui-file-dialog/pull/58) and [#67](https://github.com/fluxxcode/egui-file-dialog/pull/67)
 - Added `FileDialogLabels` and `FileDialog::labels` to enable multiple language support [#69](https://github.com/fluxxcode/egui-file-dialog/pull/69)
 - Added `FileDialog::directory_separator` to overwrite the directory separator that is used when displaying the current path [#68](https://github.com/fluxxcode/egui-file-dialog/pull/68)
+- Added `FileDialog::err_icon`, `FileDialog::folder_icon` and `FileDialog::file_icon` to customize the respective icons [#72]()
 
 #### Methods for showing or hiding certain dialog areas and functions
 - Added `FileDialog::show_top_panel` to show or hide the top panel [#60](https://github.com/fluxxcode/egui-file-dialog/pull/60)

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,13 @@ pub struct FileDialogConfig {
     /// Currently only used when the current path is displayed in the top panel.
     pub directory_separator: String,
 
+    /// The icon that is used to display error messages.
+    pub err_icon: String,
+    /// The default icon used to display files.
+    pub file_icon: String,
+    /// The default icon used to display folders.
+    pub folder_icon: String,
+
     // ------------------------------------------------------------------------
     // Window options:
     /// If set, the window title will be overwritten and set to the fixed value instead
@@ -93,6 +100,10 @@ impl Default for FileDialogConfig {
             initial_directory: std::env::current_dir().unwrap_or_default(),
             default_file_name: String::new(),
             directory_separator: String::from(">"),
+
+            err_icon: String::from("⚠"),
+            file_icon: String::from("🖹"),
+            folder_icon: String::from("🗀"),
 
             title: None,
             id: None,

--- a/src/create_directory_dialog.rs
+++ b/src/create_directory_dialog.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::FileDialogLabels;
+use crate::{FileDialogConfig, FileDialogLabels};
 
 pub struct CreateDirectoryResponse {
     /// Contains the path to the directory that was created.
@@ -79,7 +79,7 @@ impl CreateDirectoryDialog {
     pub fn update(
         &mut self,
         ui: &mut egui::Ui,
-        labels: &FileDialogLabels,
+        config: &FileDialogConfig,
     ) -> CreateDirectoryResponse {
         if !self.open {
             return CreateDirectoryResponse::new_empty();
@@ -88,7 +88,7 @@ impl CreateDirectoryDialog {
         let mut result = CreateDirectoryResponse::new_empty();
 
         ui.horizontal(|ui| {
-            ui.label("🗀");
+            ui.label(&config.folder_icon);
 
             let response = ui.text_edit_singleline(&mut self.input);
 
@@ -96,12 +96,12 @@ impl CreateDirectoryDialog {
                 response.scroll_to_me(Some(egui::Align::Center));
                 response.request_focus();
 
-                self.error = self.validate_input(labels);
+                self.error = self.validate_input(&config.labels);
                 self.init = false;
             }
 
             if response.changed() {
-                self.error = self.validate_input(labels);
+                self.error = self.validate_input(&config.labels);
             }
 
             if ui
@@ -123,7 +123,11 @@ impl CreateDirectoryDialog {
                 .horizontal_wrapped(|ui| {
                     ui.spacing_mut().item_spacing.x = 0.0;
 
-                    ui.colored_label(ui.style().visuals.error_fg_color, "⚠ ");
+                    ui.colored_label(
+                        ui.style().visuals.error_fg_color,
+                        format!("{} ", config.err_icon),
+                    );
+
                     ui.label(err);
                 })
                 .response;

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -417,6 +417,24 @@ impl FileDialog {
         self
     }
 
+    /// Sets the icon that is used to display errors.
+    pub fn err_icon(mut self, icon: &str) -> Self {
+        self.config.err_icon = icon.to_string();
+        self
+    }
+
+    /// Sets the default icon that is used to display files.
+    pub fn file_icon(mut self, icon: &str) -> Self {
+        self.config.file_icon = icon.to_string();
+        self
+    }
+
+    /// Sets the default icon that is used to display folders.
+    pub fn folder_icon(mut self, icon: &str) -> Self {
+        self.config.folder_icon = icon.to_string();
+        self
+    }
+
     /// Overwrites the window title.
     ///
     /// By default, the title is set dynamically, based on the `DialogMode`
@@ -1194,7 +1212,7 @@ impl FileDialog {
     fn ui_update_central_panel(&mut self, ui: &mut egui::Ui) {
         if let Some(err) = &self.directory_error {
             ui.centered_and_justified(|ui| {
-                ui.colored_label(egui::Color32::RED, format!("⚠ {}", err));
+                ui.colored_label(egui::Color32::RED, format!("{} {}", self.config.err_icon, err));
             });
             return;
         }
@@ -1224,8 +1242,8 @@ impl FileDialog {
                         }
 
                         let icon = match path.is_dir() {
-                            true => "🗀",
-                            _ => "🖹",
+                            true => &self.config.folder_icon,
+                            _ => &self.config.file_icon,
                         };
 
                         let mut selected = false;
@@ -1268,7 +1286,7 @@ impl FileDialog {
 
                     if let Some(path) = self
                         .create_directory_dialog
-                        .update(ui, &self.config.labels)
+                        .update(ui, &self.config)
                         .directory()
                     {
                         let entry = DirectoryEntry::from_path(&path);
@@ -1300,7 +1318,11 @@ impl FileDialog {
                     ui.horizontal_wrapped(|ui| {
                         ui.spacing_mut().item_spacing.x = 0.0;
 
-                        ui.colored_label(ui.ctx().style().visuals.error_fg_color, "⚠ ");
+                        ui.colored_label(
+                            ui.ctx().style().visuals.error_fg_color,
+                            format!("{} ", self.config.err_icon)
+                        );
+
                         ui.label(err);
                     });
                 });

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1212,7 +1212,10 @@ impl FileDialog {
     fn ui_update_central_panel(&mut self, ui: &mut egui::Ui) {
         if let Some(err) = &self.directory_error {
             ui.centered_and_justified(|ui| {
-                ui.colored_label(egui::Color32::RED, format!("{} {}", self.config.err_icon, err));
+                ui.colored_label(
+                    ui.style().visuals.error_fg_color,
+                    format!("{} {}", self.config.err_icon, err),
+                );
             });
             return;
         }
@@ -1320,7 +1323,7 @@ impl FileDialog {
 
                         ui.colored_label(
                             ui.ctx().style().visuals.error_fg_color,
-                            format!("{} ", self.config.err_icon)
+                            format!("{} ", self.config.err_icon),
                         );
 
                         ui.label(err);


### PR DESCRIPTION
Implemented `FileDialog::err_icon`, `FileDialog::folder_icon` and `FileDialog::file_icon` to customize the respective icons. At the moment only unicode is supported.