### PR TITLE
Customize device icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added `FileDialog::directory_separator` to overwrite the directory separator that is used when displaying the current path [#68](https://github.com/fluxxcode/egui-file-dialog/pull/68)
 - Added `FileDialog::err_icon`, `FileDialog::default_folder_icon` and `FileDialog::default_file_icon` to customize the respective icons [#72](https://github.com/fluxxcode/egui-file-dialog/pull/72) Renamed with [#74](https://github.com/fluxxcode/egui-file-dialog/pull/74)
 - Added `FileDialog::set_file_icon` and `FileDialogConfig::set_file_icon` to customize the icon for different types of files and directories [#74](https://github.com/fluxxcode/egui-file-dialog/pull/74)
+- Added `FileDialog::device_icon` and `FileDialog::removable_device_icon` to overwrite the icon that is used to display devices in the left panel. [#75](https://github.com/fluxxcode/egui-file-dialog/pull/75)
 
 #### Methods for showing or hiding certain dialog areas and functions
 - Added `FileDialog::show_top_panel` to show or hide the top panel [#60](https://github.com/fluxxcode/egui-file-dialog/pull/60)

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,10 @@ pub struct FileDialogConfig {
     pub default_file_icon: String,
     /// The default icon used to display folders.
     pub default_folder_icon: String,
+    /// The icon used to display devices in the left panel.
+    pub device_icon: String,
+    /// The icon used to display removable devices in the left panel.
+    pub removable_device_icon: String,
 
     /// Sets custom icons for different files or folders.
     /// Use `FileDialogConfig::set_file_icon` to add a new icon to this list.
@@ -145,6 +149,8 @@ impl Default for FileDialogConfig {
             err_icon: String::from("⚠"),
             default_file_icon: String::from("🗋"),
             default_folder_icon: String::from("🗀"),
+            device_icon: String::from("🖴"),
+            removable_device_icon: String::from("💾"),
 
             file_icon_filters: Vec::new(),
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1118,7 +1118,11 @@ impl FileDialog {
     /// Updates a device entry of a device list like "Devices" or "Removable Devices".
     fn ui_update_device_entry(&mut self, ui: &mut egui::Ui, device: &Disk) {
         let label = match device.is_removable() {
-            true => format!("{}  {}", self.config.removable_device_icon, device.display_name()),
+            true => format!(
+                "{}  {}",
+                self.config.removable_device_icon,
+                device.display_name()
+            ),
             false => format!("{}  {}", self.config.device_icon, device.display_name()),
         };
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -433,6 +433,18 @@ impl FileDialog {
         self
     }
 
+    /// Sets the icon that is used to display devices in the left panel.
+    pub fn device_icon(mut self, icon: &str) -> Self {
+        self.config.device_icon = icon.to_string();
+        self
+    }
+
+    /// Sets the icon that is used to display removable devices in the left panel.
+    pub fn removable_device_icon(mut self, icon: &str) -> Self {
+        self.config.removable_device_icon = icon.to_string();
+        self
+    }
+
     /// Sets a new icon for specific files or folders.
     ///
     /// # Arguments
@@ -1106,8 +1118,8 @@ impl FileDialog {
     /// Updates a device entry of a device list like "Devices" or "Removable Devices".
     fn ui_update_device_entry(&mut self, ui: &mut egui::Ui, device: &Disk) {
         let label = match device.is_removable() {
-            true => format!("💾  {}", device.display_name()),
-            false => format!("🖴  {}", device.display_name()),
+            true => format!("{}  {}", self.config.removable_device_icon, device.display_name()),
+            false => format!("{}  {}", self.config.device_icon, device.display_name()),
         };
 
         if ui.selectable_label(false, label).clicked() {


### PR DESCRIPTION
Implemented `FileDialog::device_icon` and `FileDialog::removable_device_icon` to overwrite the icon that is used to display devices in the left panel.