### PR TITLE
Added labels_mut and config_mut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 ### ✨ Features
 - Added `FileDialog::take_selected` as an alternative to `FileDialog::selected` [#52](https://github.com/fluxxcode/egui-file-dialog/pull/52)
-- Added `FileDialogConfig`, `FileDialog::with_config` and `FileDialog::overwrite_config` to set and override the configuration of a file dialog. This is useful if you want to configure multiple `FileDialog` objects with the same options. [#58](https://github.com/fluxxcode/egui-file-dialog/pull/58) and [#67](https://github.com/fluxxcode/egui-file-dialog/pull/67)
-- Added `FileDialogLabels` and `FileDialog::labels` to enable multiple language support [#69](https://github.com/fluxxcode/egui-file-dialog/pull/69)
+- Added `FileDialogConfig`, `FileDialog::with_config`, `FileDialog::overwrite_config` and `FileDialog::config_mut` to set and override the configuration of a file dialog. This is useful if you want to configure multiple `FileDialog` objects with the same options. [#58](https://github.com/fluxxcode/egui-file-dialog/pull/58), [#67](https://github.com/fluxxcode/egui-file-dialog/pull/67) and [#79](https://github.com/fluxxcode/egui-file-dialog/pull/79)
+- Added `FileDialogLabels`, `FileDialog::labels` and `FileDialog::labels_mut` to enable multiple language support [#69](https://github.com/fluxxcode/egui-file-dialog/pull/69) and [#79](https://github.com/fluxxcode/egui-file-dialog/pull/79)
 - Added `FileDialog::directory_separator` to overwrite the directory separator that is used when displaying the current path [#68](https://github.com/fluxxcode/egui-file-dialog/pull/68)
 - Added `FileDialog::err_icon`, `FileDialog::default_folder_icon` and `FileDialog::default_file_icon` to customize the respective icons [#72](https://github.com/fluxxcode/egui-file-dialog/pull/72) Renamed with [#74](https://github.com/fluxxcode/egui-file-dialog/pull/74)
 - Added `FileDialog::set_file_icon` and `FileDialogConfig::set_file_icon` to customize the icon for different types of files and directories [#74](https://github.com/fluxxcode/egui-file-dialog/pull/74)

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -370,6 +370,11 @@ impl FileDialog {
         self
     }
 
+    /// Mutably borrow internal `config`.
+    pub fn config_mut(&mut self) -> &mut FileDialogConfig {
+        &mut self.config
+    }
+
     /// Sets the labels the file dialog uses.
     ///
     /// Used to enable multiple language support.
@@ -378,6 +383,11 @@ impl FileDialog {
     pub fn labels(mut self, labels: FileDialogLabels) -> Self {
         self.config.labels = labels;
         self
+    }
+
+    /// Mutably borrow internal `config.labels`.
+    pub fn labels_mut(&mut self) -> &mut FileDialogLabels {
+        &mut self.config.labels
     }
 
     /// Sets the first loaded directory when the dialog opens.


### PR DESCRIPTION
Implemented `FileDialog::labels_mut` and `FileDialog::config_mut` so we don't have to clone the dialog when updating labels or config.