### PR TITLE
clear `search_value` on dir load

### DIFF
--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -54,7 +54,7 @@ pub enum DialogState {
 ///         if ui.button("Select a file").clicked() {
 ///             self.file_dialog.select_file();
 ///         }
-///         
+///
 ///         if let Some(path) = self.file_dialog.update(ctx).selected() {
 ///             println!("Selected file: {:?}", path);
 ///         }
@@ -1198,6 +1198,8 @@ impl FileDialog {
     ///
     /// The function also sets the loaded directory as the selected item.
     fn load_directory(&mut self, path: &Path) -> io::Result<()> {
+        self.search_value.clear();
+
         let full_path = match fs::canonicalize(path) {
             Ok(path) => path,
             Err(err) => {


### PR DESCRIPTION
simply clear the search value upon entering another directory.