### PR TITLE
Automatically edit filter string when user is typing

### DIFF
--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1037,42 +1037,50 @@ impl FileDialog {
                         egui::Vec2::new(ui.available_width(), 0.0),
                         egui::TextEdit::singleline(&mut self.search_value),
                     );
-                    // Trigger entry filter input when typing is detected and nothing else is focused
-                    let mut focused = re.has_focus();
-                    ui.memory(|mem| {
-                        if mem.focus().is_some() {
-                            focused = true;
-                        }
-                    });
-                    if !focused && !self.path_edit_visible {
-                        let mut focus = false;
-                        ui.input(|inp| {
-                            if inp.modifiers.any() && !inp.modifiers.shift_only() {
-                                return;
-                            }
-
-                            for text in inp.events.iter().filter_map(|ev| match ev {
-                                egui::Event::Text(t) => Some(t),
-                                _ => None,
-                            }) {
-                                self.search_value.push_str(text);
-                                focus = true;
-                            }
-                        });
-                        if focus {
-                            re.request_focus();
-                            if let Some(mut state) = egui::TextEdit::load_state(ui.ctx(), re.id) {
-                                state
-                                    .cursor
-                                    .set_char_range(Some(CCursorRange::one(CCursor::new(
-                                        self.search_value.len(),
-                                    ))));
-                                state.store(ui.ctx(), re.id);
-                            }
-                        }
-                    }
+                    self.edit_filter_on_text_input(ui, re);
                 });
             });
+    }
+    /// Focuses and types into the filter input, if text input without
+    /// shortcut modifiers is detected, and no other inputs are focused.
+    ///
+    /// # Arguments
+    ///
+    /// - `re`: The [`egui::Response`] returned by the filter text edit widget
+    fn edit_filter_on_text_input(&mut self, ui: &mut egui::Ui, re: egui::Response) {
+        let mut focused = re.has_focus();
+        ui.memory(|mem| {
+            if mem.focus().is_some() {
+                focused = true;
+            }
+        });
+        if !focused && !self.path_edit_visible {
+            let mut focus = false;
+            ui.input(|inp| {
+                if inp.modifiers.any() && !inp.modifiers.shift_only() {
+                    return;
+                }
+
+                for text in inp.events.iter().filter_map(|ev| match ev {
+                    egui::Event::Text(t) => Some(t),
+                    _ => None,
+                }) {
+                    self.search_value.push_str(text);
+                    focus = true;
+                }
+            });
+            if focus {
+                re.request_focus();
+                if let Some(mut state) = egui::TextEdit::load_state(ui.ctx(), re.id) {
+                    state
+                        .cursor
+                        .set_char_range(Some(CCursorRange::one(CCursor::new(
+                            self.search_value.len(),
+                        ))));
+                    state.store(ui.ctx(), re.id);
+                }
+            }
+        }
     }
 
     /// Updates the left panel of the dialog. Including the list of the user directories (Places)

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1759,6 +1759,10 @@ impl FileDialog {
         let dir_entry = DirectoryEntry::from_path(&self.config, path);
         self.select_item(&dir_entry);
 
+        // Clear the entry filter buffer.
+        // It's unlikely the user wants to keep the current filter when entering a new directory.
+        self.search_value.clear();
+
         Ok(())
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1759,10 +1759,6 @@ impl FileDialog {
         let dir_entry = DirectoryEntry::from_path(&self.config, path);
         self.select_item(&dir_entry);
 
-        // Clear the entry filter buffer.
-        // It's unlikely the user wants to keep the current filter when entering a new directory.
-        self.search_value.clear();
-
         Ok(())
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1736,8 +1736,6 @@ impl FileDialog {
     ///
     /// The function also sets the loaded directory as the selected item.
     fn load_directory(&mut self, path: &Path) -> io::Result<()> {
-        self.search_value.clear();
-
         // Do not load the same directory again.
         // Use reload_directory if the content of the directory should be updated.
         if let Some(x) = self.current_directory() {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1055,10 +1055,12 @@ impl FileDialog {
         // Whether to activate the text input widget
         let mut activate = false;
         ui.input(|inp| {
+            // We stop if any modifier is active besides only shift
             if inp.modifiers.any() && !inp.modifiers.shift_only() {
                 return;
             }
-
+            // If we find any text input event, we append it to the filter string
+            // and allow proceeding to activating the filter input widget.
             for text in inp.events.iter().filter_map(|ev| match ev {
                 egui::Event::Text(t) => Some(t),
                 _ => None,
@@ -1068,7 +1070,9 @@ impl FileDialog {
             }
         });
         if activate {
+            // Focus the filter input widget
             re.request_focus();
+            // Set the cursor to the end of the filter input string
             if let Some(mut state) = egui::TextEdit::load_state(ui.ctx(), re.id) {
                 state
                     .cursor

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1040,7 +1040,7 @@ impl FileDialog {
                     // Trigger entry filter input when typing is detected and nothing else is focused
                     let mut focused = re.has_focus();
                     ui.memory(|mem| {
-                        if let Some(_) = mem.focus() {
+                        if mem.focus().is_some() {
                             focused = true;
                         }
                     });

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1052,7 +1052,8 @@ impl FileDialog {
         if any_focused {
             return;
         }
-        let mut focus = false;
+        // Whether to activate the text input widget
+        let mut activate = false;
         ui.input(|inp| {
             if inp.modifiers.any() && !inp.modifiers.shift_only() {
                 return;
@@ -1063,10 +1064,10 @@ impl FileDialog {
                 _ => None,
             }) {
                 self.search_value.push_str(text);
-                focus = true;
+                activate = true;
             }
         });
-        if focus {
+        if activate {
             re.request_focus();
             if let Some(mut state) = egui::TextEdit::load_state(ui.ctx(), re.id) {
                 state

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1055,13 +1055,8 @@ impl FileDialog {
                                 egui::Event::Text(t) => Some(t),
                                 _ => None,
                             }) {
-                                if text.starts_with("/") {
-                                    self.path_edit_visible = true;
-                                    self.path_edit_request_focus = true;
-                                } else {
-                                    self.search_value.push_str(text);
-                                    focus = true;
-                                }
+                                self.search_value.push_str(text);
+                                focus = true;
                             }
                         });
                         if focus {
@@ -1069,7 +1064,9 @@ impl FileDialog {
                             if let Some(mut state) = egui::TextEdit::load_state(ui.ctx(), re.id) {
                                 state
                                     .cursor
-                                    .set_char_range(Some(CCursorRange::one(CCursor::new(self.search_value.len()))));
+                                    .set_char_range(Some(CCursorRange::one(CCursor::new(
+                                        self.search_value.len(),
+                                    ))));
                                 state.store(ui.ctx(), re.id);
                             }
                         }


### PR DESCRIPTION
Fixes #89 


## Requirements from #89
There are also a few points about when we want to avoid the behavior:

- [ ] When the user presses Ctrl or ~~Shift~~ so that we can implement Key bindings in the future
    - [x] Allow shift, but not other modifiers.
      Shift is probably desirable for capitalizing letters, so we want to allow editing while shift is being held down.
- [x] When the user is already in any input field
   This seems to be working.

## Extra behavior added
- The filter string is cleared when a new directory is entered. I think this behavior is desirable because it's much less likely that the user wants to keep the current filter when entering a new directory, rather than wanting to either see the unfiltered contents, or type a new filter from scratch. We could possibly add a way to configure this behavior in the future though.

## Credits
@aymey made the changes to satisfy the requirements of not activating the behavior. Sorry, your commits got lost because I did a rebase against the latest develop revision.