### PR TITLE
Ability to pin folders to the left sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # egui-file-dialog changelog
 
 ## Unreleased - v0.6.0
+### ✨ Features
+- Added the ability to pin folders to the left sidebar and enable or disable the feature with `FileDialog::show_pinned_folders` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100)
+
 ### 🐛 Bug Fixes
 - Fixed the size of the path edit input box and fixed an issue where the path edit would not close when clicking the apply button [#102](https://github.com/fluxxcode/egui-file-dialog/pull/102)
 

--- a/examples/multilingual/src/main.rs
+++ b/examples/multilingual/src/main.rs
@@ -15,6 +15,7 @@ fn get_labels_german() -> FileDialogLabels {
         title_select_file: "📂 Datei Öffnen".to_string(),
         title_save_file: "📥 Datei Speichern".to_string(),
 
+        heading_pinned: "Angeheftet".to_string(),
         heading_places: "Orte".to_string(),
         heading_devices: "Medien".to_string(),
         heading_removable_devices: "Wechselmedien".to_string(),
@@ -26,6 +27,9 @@ fn get_labels_german() -> FileDialogLabels {
         audio_dir: "🎵  Audio".to_string(),
         pictures_dir: "🖼  Fotos".to_string(),
         videos_dir: "🎞  Videos".to_string(),
+
+        pin_folder: "📌 Ordner anheften".to_string(),
+        unpin_folder: "✖ Ordner loslösen".to_string(),
 
         selected_directory: "Ausgewählter Ordner:".to_string(),
         selected_file: "Ausgewählte Datei:".to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,6 +111,8 @@ pub struct FileDialogConfig {
     pub default_file_icon: String,
     /// The default icon used to display folders.
     pub default_folder_icon: String,
+    /// The icon used to display pinned paths in the left panel.
+    pub pinned_icon: String,
     /// The icon used to display devices in the left panel.
     pub device_icon: String,
     /// The icon used to display removable devices in the left panel.
@@ -199,6 +201,7 @@ impl Default for FileDialogConfig {
             err_icon: String::from("⚠"),
             default_file_icon: String::from("🗋"),
             default_folder_icon: String::from("🗀"),
+            pinned_icon: String::from("📌"),
             device_icon: String::from("🖴"),
             removable_device_icon: String::from("💾"),
 
@@ -331,6 +334,8 @@ pub struct FileDialogLabels {
 
     // ------------------------------------------------------------------------
     // Left panel:
+    /// Heading of the "Pinned" sections in the left panel
+    pub heading_pinned: String,
     /// Heading of the "Places" section in the left panel
     pub heading_places: String,
     /// Heading of the "Devices" section in the left panel
@@ -352,6 +357,13 @@ pub struct FileDialogLabels {
     pub pictures_dir: String,
     /// Name of the videos directory
     pub videos_dir: String,
+
+    // ------------------------------------------------------------------------
+    // Central panel:
+    /// Text used for the option to pin a folder.
+    pub pin_folder: String,
+    /// Text used for the option to unpin a folder.
+    pub unpin_folder: String,
 
     // ------------------------------------------------------------------------
     // Bottom panel:
@@ -389,6 +401,7 @@ impl Default for FileDialogLabels {
             title_select_file: "📂 Open File".to_string(),
             title_save_file: "📥 Save File".to_string(),
 
+            heading_pinned: "Pinned".to_string(),
             heading_places: "Places".to_string(),
             heading_devices: "Devices".to_string(),
             heading_removable_devices: "Removable Devices".to_string(),
@@ -400,6 +413,9 @@ impl Default for FileDialogLabels {
             audio_dir: "🎵  Audio".to_string(),
             pictures_dir: "🖼  Pictures".to_string(),
             videos_dir: "🎞  Videos".to_string(),
+
+            pin_folder: "📌 Pin folder".to_string(),
+            unpin_folder: "✖ Unpin folder".to_string(),
 
             selected_directory: "Selected directory:".to_string(),
             selected_file: "Selected file:".to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -175,6 +175,9 @@ pub struct FileDialogConfig {
     /// If the sidebar with the shortcut directories such as
     /// “Home”, “Documents” etc. should be visible.
     pub show_left_panel: bool,
+    /// If pinned folders should be listed in the left sidebar.
+    /// Disabling this will also disable the functionality to pin a folder.
+    pub show_pinned_folders: bool,
     /// If the Places section in the left sidebar should be visible.
     pub show_places: bool,
     /// If the Devices section in the left sidebar should be visible.
@@ -226,6 +229,7 @@ impl Default for FileDialogConfig {
             show_search: true,
 
             show_left_panel: true,
+            show_pinned_folders: true,
             show_places: true,
             show_devices: true,
             show_removable_devices: true,

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -50,6 +50,11 @@ impl DirectoryEntry {
     }
 
     /// Returns the path of the directory item.
+    pub fn as_path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Clones the path of the directory item.
     pub fn to_path_buf(&self) -> PathBuf {
         self.path.clone()
     }

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -6,7 +6,7 @@ use crate::FileDialogConfig;
 /// Contains the metadata of a directory item.
 /// This struct is mainly there so that the metadata can be loaded once and not that
 /// a request has to be sent to the OS every frame using, for example, `path.is_file()`.
-#[derive(Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct DirectoryEntry {
     path: PathBuf,
     is_directory: bool,

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -37,12 +37,12 @@ pub enum DialogState {
 }
 
 /// Contains data of the FileDialog that should be stored persistently.
-struct FileDialogPersistentData {
+struct FileDialogStorage {
     /// The folders the user pinned to the left sidebar.
     pub pinned_folders: Vec<DirectoryEntry>,
 }
 
-impl Default for FileDialogPersistentData {
+impl Default for FileDialogStorage {
     /// Creates a new object with default values
     fn default() -> Self {
         Self {
@@ -80,7 +80,7 @@ pub struct FileDialog {
     /// The configuration of the file dialog
     config: FileDialogConfig,
     /// Persistent data of the file dialog
-    persistent_data: FileDialogPersistentData,
+    storage: FileDialogStorage,
 
     /// The mode the dialog is currently in
     mode: DialogMode,
@@ -157,7 +157,7 @@ impl FileDialog {
     pub fn new() -> Self {
         Self {
             config: FileDialogConfig::default(),
-            persistent_data: FileDialogPersistentData::default(),
+            storage: FileDialogStorage::default(),
 
             mode: DialogMode::SelectDirectory,
             state: DialogState::Closed,
@@ -1219,13 +1219,7 @@ impl FileDialog {
     fn ui_update_pinned_paths(&mut self, ui: &mut egui::Ui, spacing: f32) -> bool {
         let mut visible = false;
 
-        for (i, path) in self
-            .persistent_data
-            .pinned_folders
-            .clone()
-            .iter()
-            .enumerate()
-        {
+        for (i, path) in self.storage.pinned_folders.clone().iter().enumerate() {
             if i == 0 {
                 ui.add_space(spacing);
                 ui.label(self.config.labels.heading_pinned.as_str());
@@ -1655,20 +1649,17 @@ impl FileDialog {
 
     /// Pins a path to the left sidebar.
     fn pin_path(&mut self, path: DirectoryEntry) {
-        self.persistent_data.pinned_folders.push(path);
+        self.storage.pinned_folders.push(path);
     }
 
     /// Unpins a path from the left sidebar.
     fn unpin_path(&mut self, path: &DirectoryEntry) {
-        self.persistent_data.pinned_folders.retain(|p| p != path);
+        self.storage.pinned_folders.retain(|p| p != path);
     }
 
     /// Checks if the path is pinned to the left sidebar.
     fn is_pinned(&self, path: &DirectoryEntry) -> bool {
-        self.persistent_data
-            .pinned_folders
-            .iter()
-            .any(|p| path == p)
+        self.storage.pinned_folders.iter().any(|p| path == p)
     }
 
     /// Resets the dialog to use default values.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1513,19 +1513,26 @@ impl FileDialog {
                             selected = x == path;
                         }
 
-                        let response =
-                            ui.selectable_label(selected, format!("{} {}", path.icon(), file_name));
+                        let pinned = self.is_pinned(path);
+                        let label = match pinned {
+                            true => {
+                                format!("{} {} {}", path.icon(), self.config.pinned_icon, file_name)
+                            }
+                            false => format!("{} {}", path.icon(), file_name),
+                        };
+
+                        let response = ui.selectable_label(selected, label);
 
                         if path.is_dir() {
                             response.context_menu(|ui| {
-                                if self.is_pinned(path) {
-                                    if ui.button(&self.config.labels.pin_folder).clicked() {
-                                        self.pin_path(path.clone());
+                                if pinned {
+                                    if ui.button(&self.config.labels.unpin_folder).clicked() {
+                                        self.unpin_path(path);
                                         ui.close_menu();
                                     }
                                 } else {
-                                    if ui.button(&self.config.labels.unpin_folder).clicked() {
-                                        self.unpin_path(path);
+                                    if ui.button(&self.config.labels.pin_folder).clicked() {
+                                        self.pin_path(path.clone());
                                         ui.close_menu();
                                     }
                                 }
@@ -1636,7 +1643,7 @@ impl FileDialog {
 
     /// Checks if the path is pinned to the left sidebar.
     fn is_pinned(&self, path: &DirectoryEntry) -> bool {
-        !self.pinned_folders.iter().any(|p| path == p)
+        self.pinned_folders.iter().any(|p| path == p)
     }
 
     /// Resets the dialog to use default values.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1620,7 +1620,6 @@ impl FileDialog {
         }
 
         item_response.context_menu(|ui| {
-            // TODO: We definitely want to save the pinned status in the DirectoryEntry object!
             let pinned = self.is_pinned(path);
 
             if pinned {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -664,6 +664,13 @@ impl FileDialog {
         self
     }
 
+    /// Sets if pinned folders should be listed in the left sidebar.
+    /// Disabling this will also disable the functionality to pin a folder.
+    pub fn show_pinned_folders(mut self, show_pinned_folders: bool) -> Self {
+        self.config.show_pinned_folders = show_pinned_folders;
+        self
+    }
+
     /// Sets if the "Places" section should be visible in the left sidebar.
     /// The Places section contains the user directories such as Home or Documents.
     ///

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1608,11 +1608,9 @@ impl FileDialog {
                     self.unpin_path(path);
                     ui.close_menu();
                 }
-            } else {
-                if ui.button(&self.config.labels.pin_folder).clicked() {
-                    self.pin_path(path.clone());
-                    ui.close_menu();
-                }
+            } else if ui.button(&self.config.labels.pin_folder).clicked() {
+                self.pin_path(path.clone());
+                ui.close_menu();
             }
         });
     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1447,6 +1447,12 @@ impl FileDialog {
                         let response =
                             ui.selectable_label(selected, format!("{} {}", path.icon(), file_name));
 
+                        if path.is_dir() {
+                            response.context_menu(|ui| {
+                                ui.label("Pin folder");
+                            });
+                        }
+
                         if selected && self.scroll_to_selection {
                             response.scroll_to_me(Some(egui::Align::Center));
                         }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1219,7 +1219,13 @@ impl FileDialog {
     fn ui_update_pinned_paths(&mut self, ui: &mut egui::Ui, spacing: f32) -> bool {
         let mut visible = false;
 
-        for (i, path) in self.persistent_data.pinned_folders.clone().iter().enumerate() {
+        for (i, path) in self
+            .persistent_data
+            .pinned_folders
+            .clone()
+            .iter()
+            .enumerate()
+        {
             if i == 0 {
                 ui.add_space(spacing);
                 ui.label(self.config.labels.heading_pinned.as_str());
@@ -1659,7 +1665,10 @@ impl FileDialog {
 
     /// Checks if the path is pinned to the left sidebar.
     fn is_pinned(&self, path: &DirectoryEntry) -> bool {
-        self.persistent_data.pinned_folders.iter().any(|p| path == p)
+        self.persistent_data
+            .pinned_folders
+            .iter()
+            .any(|p| path == p)
     }
 
     /// Resets the dialog to use default values.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -36,6 +36,21 @@ pub enum DialogState {
     Cancelled,
 }
 
+/// Contains data of the FileDialog that should be stored persistently.
+struct FileDialogPersistentData {
+    /// The folders the user pinned to the left sidebar.
+    pub pinned_folders: Vec<DirectoryEntry>,
+}
+
+impl Default for FileDialogPersistentData {
+    /// Creates a new object with default values
+    fn default() -> Self {
+        Self {
+            pinned_folders: Vec::new(),
+        }
+    }
+}
+
 /// Represents a file dialog instance.
 ///
 /// The `FileDialog` instance can be used multiple times and for different actions.
@@ -64,6 +79,8 @@ pub enum DialogState {
 pub struct FileDialog {
     /// The configuration of the file dialog
     config: FileDialogConfig,
+    /// Persistent data of the file dialog
+    persistent_data: FileDialogPersistentData,
 
     /// The mode the dialog is currently in
     mode: DialogMode,
@@ -79,8 +96,6 @@ pub struct FileDialog {
     /// This ID is not used internally.
     operation_id: Option<String>,
 
-    /// The folders the user pinned to the left sidebar.
-    pinned_folders: Vec<DirectoryEntry>,
     /// The user directories like Home or Documents.
     /// These are loaded once when the dialog is created or when the refresh() method is called.
     user_directories: Option<UserDirectories>,
@@ -142,13 +157,13 @@ impl FileDialog {
     pub fn new() -> Self {
         Self {
             config: FileDialogConfig::default(),
+            persistent_data: FileDialogPersistentData::default(),
 
             mode: DialogMode::SelectDirectory,
             state: DialogState::Closed,
             show_files: true,
             operation_id: None,
 
-            pinned_folders: Vec::new(),
             user_directories: UserDirectories::new(true),
             system_disks: Disks::new_with_refreshed_list(true),
 
@@ -1204,7 +1219,7 @@ impl FileDialog {
     fn ui_update_pinned_paths(&mut self, ui: &mut egui::Ui, spacing: f32) -> bool {
         let mut visible = false;
 
-        for (i, path) in self.pinned_folders.clone().iter().enumerate() {
+        for (i, path) in self.persistent_data.pinned_folders.clone().iter().enumerate() {
             if i == 0 {
                 ui.add_space(spacing);
                 ui.label(self.config.labels.heading_pinned.as_str());
@@ -1634,17 +1649,17 @@ impl FileDialog {
 
     /// Pins a path to the left sidebar.
     fn pin_path(&mut self, path: DirectoryEntry) {
-        self.pinned_folders.push(path);
+        self.persistent_data.pinned_folders.push(path);
     }
 
     /// Unpins a path from the left sidebar.
     fn unpin_path(&mut self, path: &DirectoryEntry) {
-        self.pinned_folders.retain(|p| p != path);
+        self.persistent_data.pinned_folders.retain(|p| p != path);
     }
 
     /// Checks if the path is pinned to the left sidebar.
     fn is_pinned(&self, path: &DirectoryEntry) -> bool {
-        self.pinned_folders.iter().any(|p| path == p)
+        self.persistent_data.pinned_folders.iter().any(|p| path == p)
     }
 
     /// Resets the dialog to use default values.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1132,7 +1132,7 @@ impl FileDialog {
                     const SPACING_MULTIPLIER: f32 = 4.0;
 
                     // Update paths pinned to the left sidebar by the user
-                    if self.ui_update_pinned_paths(ui, spacing) {
+                    if self.config.show_pinned_folders && self.ui_update_pinned_paths(ui, spacing) {
                         spacing = ui.ctx().style().spacing.item_spacing.y * SPACING_MULTIPLIER;
                     }
 
@@ -1599,6 +1599,11 @@ impl FileDialog {
         item_response: &egui::Response,
         path: &DirectoryEntry,
     ) {
+        // Path context menus are currently only used for pinned folders.
+        if !self.config.show_pinned_folders {
+            return;
+        }
+
         item_response.context_menu(|ui| {
             // TODO: We definitely want to save the pinned status in the DirectoryEntry object!
             let pinned = self.is_pinned(path);


### PR DESCRIPTION
Implemented the ability to pin folders to the left sidebar and enable or disable the feature with `FileDialog::show_pinned_folders`.
This pull request does not implement persistent storage. Therefore, the pinned folders are deleted after a new `FileDialog` object is created. The feature that the data can be saved persistently will be implemented with a new PR.

https://github.com/fluxxcode/egui-file-dialog/assets/55352293/3df9772f-8bfa-4ac3-a786-9e8866e2e498

Ref: https://github.com/fluxxcode/egui-file-dialog/issues/42