### PR TITLE
Fix path edit size and focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # egui-file-dialog changelog
 
+## Unreleased - v0.6.0
+### 🐛 Bug Fixes
+- Fixed the size of the path edit input box and fixed an issue where the path edit would not close when clicking the apply button [#102](https://github.com/fluxxcode/egui-file-dialog/pull/102)
+
 ## 2024-03-30 - v0.5.0 - egui update and QoL changes
 ### 🚨 Breaking Changes
 - Updated `egui` from version `0.26.0` to version `0.27.1` [#97](https://github.com/fluxxcode/egui-file-dialog/pull/97)

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1029,18 +1029,17 @@ impl FileDialog {
             self.path_edit_request_focus = false;
         }
 
+        let btn_response = ui.add_sized(edit_button_size, egui::Button::new("✔"));
+
+        if btn_response.clicked() {
+            self.load_path_edit_directory(true);
+        }
+
         if response.lost_focus() && ui.ctx().input(|input| input.key_pressed(egui::Key::Enter)) {
             self.path_edit_request_focus = true;
             self.load_path_edit_directory(false);
-        } else if !response.has_focus() {
+        } else if !response.has_focus() && !btn_response.contains_pointer() {
             self.path_edit_visible = false;
-        }
-
-        if ui
-            .add_sized(edit_button_size, egui::Button::new("✔"))
-            .clicked()
-        {
-            self.load_path_edit_directory(true);
         }
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1017,7 +1017,7 @@ impl FileDialog {
     /// Updates the view when the user currently wants to text edit the current path.
     fn ui_update_path_edit(&mut self, ui: &mut egui::Ui, width: f32, edit_button_size: egui::Vec2) {
         let desired_width: f32 =
-            width - edit_button_size.x - ui.style().spacing.item_spacing.x * 2.0;
+            width - edit_button_size.x - ui.style().spacing.item_spacing.x * 3.0;
 
         let response = egui::TextEdit::singleline(&mut self.path_edit_value)
             .desired_width(desired_width)


### PR DESCRIPTION
- Fixed the size of the path edit input field because it was too large
- Fixed issue where path edit would not close when the apply path edit button was pressed