### PR TITLE
Deprecate FileDialog::overwrite_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### ✨ Features
 - Added the ability to pin folders to the left sidebar and enable or disable the feature with `FileDialog::show_pinned_folders` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100)
 
+### ☢️ Deprecated
+- Deprecated `FileDialog::overwrite_config`. Use `FileDialog::with_config` and `FileDialog::config_mut` instead [#103](https://github.com/fluxxcode/egui-file-dialog/pull/103)
+
 ### 🐛 Bug Fixes
 - Fixed the size of the path edit input box and fixed an issue where the path edit would not close when clicking the apply button [#102](https://github.com/fluxxcode/egui-file-dialog/pull/102)
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,8 +61,7 @@ impl QuickAccess {
 
 /// Contains configuration values of a file dialog.
 ///
-/// The configuration of a file dialog can be set using
-/// `FileDialog::with_config` or `FileDialog::overwrite_config`.
+/// The configuration of a file dialog can be set using `FileDialog::with_config`.
 ///
 /// If you only need to configure a single file dialog, you don't need to
 /// manually use a `FileDialogConfig` object. `FileDialog` provides setter methods for

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -189,7 +189,9 @@ impl FileDialog {
 
     /// Creates a new file dialog object and initializes it with the specified configuration.
     pub fn with_config(config: FileDialogConfig) -> Self {
-        Self::new().overwrite_config(config)
+        let mut obj = Self::new();
+        *obj.config_mut() = config;
+        obj
     }
 
     // -------------------------------------------------
@@ -380,6 +382,10 @@ impl FileDialog {
     ///     }
     /// }
     /// ```
+    #[deprecated(
+        since = "0.6.0",
+        note = "use `FileDialog::with_config` and `FileDialog::config_mut` instead"
+    )]
     pub fn overwrite_config(mut self, config: FileDialogConfig) -> Self {
         self.config = config;
         self


### PR DESCRIPTION
`FileDialog::overwrite_config` has been deprecated because it is quite confusing to use and provides no value. \
`FileDialog::with_config` and `FileDialog::config_mut` should be used instead.