### PR TITLE
Implement persistent storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased - v0.6.0
 ### ✨ Features
 - Added the ability to pin folders to the left sidebar and enable or disable the feature with `FileDialog::show_pinned_folders` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100)
+- Added `FileDialog::storage_mut` to be able to save and load the pinned folders [#104](https://github.com/fluxxcode/egui-file-dialog/pull/104)
 
 ### ☢️ Deprecated
 - Deprecated `FileDialog::overwrite_config`. Use `FileDialog::with_config` and `FileDialog::config_mut` instead [#103](https://github.com/fluxxcode/egui-file-dialog/pull/103)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,8 @@ directories = "5.0"
 sysinfo = { version = "0.30.5", default-features = false }
 
 # Used for persistent storage
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"], optional = true}
+
+[features]
+default = ["persistence"]
+persistence = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ directories = "5.0"
 
 # Used to fetch disks
 sysinfo = { version = "0.30.5", default-features = false }
+
+# Used for persistent storage
+serde = { version = "1", features = ["derive"] }

--- a/examples/sandbox/Cargo.toml
+++ b/examples/sandbox/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eframe = { version = "0.27.1", default-features = false, features = ["glow"] }
+eframe = { version = "0.27.1", default-features = false, features = ["glow", "persistence"] }
 egui-file-dialog = { path = "../../"}

--- a/examples/sandbox/Cargo.toml
+++ b/examples/sandbox/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 eframe = { version = "0.27.1", default-features = false, features = ["glow", "persistence"] }
-egui-file-dialog = { path = "../../"}
+egui-file-dialog = { path = "../../" }

--- a/examples/sandbox/src/main.rs
+++ b/examples/sandbox/src/main.rs
@@ -27,7 +27,7 @@ impl MyApp {
         }
 
         Self {
-            file_dialog: file_dialog,
+            file_dialog,
 
             selected_directory: None,
             selected_file: None,

--- a/examples/sandbox/src/main.rs
+++ b/examples/sandbox/src/main.rs
@@ -38,7 +38,11 @@ impl MyApp {
 
 impl eframe::App for MyApp {
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
-        eframe::set_value(storage, "file_dialog_storage", self.file_dialog.storage_mut());
+        eframe::set_value(
+            storage,
+            "file_dialog_storage",
+            self.file_dialog.storage_mut(),
+        );
     }
 
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {

--- a/examples/sandbox/src/main.rs
+++ b/examples/sandbox/src/main.rs
@@ -38,7 +38,7 @@ impl MyApp {
 
 impl eframe::App for MyApp {
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
-        eframe::set_value(storage, "fd_storage", self.file_dialog.storage_mut());
+        eframe::set_value(storage, "file_dialog_storage", self.file_dialog.storage_mut());
     }
 
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {

--- a/examples/sandbox/src/main.rs
+++ b/examples/sandbox/src/main.rs
@@ -12,7 +12,7 @@ struct MyApp {
 }
 
 impl MyApp {
-    pub fn new(_cc: &eframe::CreationContext) -> Self {
+    pub fn new(cc: &eframe::CreationContext) -> Self {
         let mut file_dialog = FileDialog::new()
             .add_quick_access("Project", |s| {
                 s.add_path("☆  Examples", "examples");
@@ -21,7 +21,7 @@ impl MyApp {
             })
             .id("egui_file_dialog");
 
-        if let Some(storage) = _cc.storage {
+        if let Some(storage) = cc.storage {
             *file_dialog.storage_mut() =
                 eframe::get_value(storage, "file_dialog_storage").unwrap_or_default()
         }

--- a/examples/sandbox/src/main.rs
+++ b/examples/sandbox/src/main.rs
@@ -13,14 +13,21 @@ struct MyApp {
 
 impl MyApp {
     pub fn new(_cc: &eframe::CreationContext) -> Self {
+        let mut file_dialog = FileDialog::new()
+            .add_quick_access("Project", |s| {
+                s.add_path("☆  Examples", "examples");
+                s.add_path("📷  Media", "media");
+                s.add_path("📂  Source", "src");
+            })
+            .id("egui_file_dialog");
+
+        if let Some(storage) = _cc.storage {
+            *file_dialog.storage_mut() =
+                eframe::get_value(storage, "file_dialog_storage").unwrap_or_default()
+        }
+
         Self {
-            file_dialog: FileDialog::new()
-                .add_quick_access("Project", |s| {
-                    s.add_path("☆  Examples", "examples");
-                    s.add_path("📷  Media", "media");
-                    s.add_path("📂  Source", "src");
-                })
-                .id("egui_file_dialog"),
+            file_dialog: file_dialog,
 
             selected_directory: None,
             selected_file: None,
@@ -30,6 +37,10 @@ impl MyApp {
 }
 
 impl eframe::App for MyApp {
+    fn save(&mut self, storage: &mut dyn eframe::Storage) {
+        eframe::set_value(storage, "fd_storage", self.file_dialog.storage_mut());
+    }
+
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("My egui application");

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -6,7 +6,7 @@ use crate::FileDialogConfig;
 /// Contains the metadata of a directory item.
 /// This struct is mainly there so that the metadata can be loaded once and not that
 /// a request has to be sent to the OS every frame using, for example, `path.is_file()`.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct DirectoryEntry {
     path: PathBuf,
     is_directory: bool,

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -6,7 +6,8 @@ use crate::FileDialogConfig;
 /// Contains the metadata of a directory item.
 /// This struct is mainly there so that the metadata can be loaded once and not that
 /// a request has to be sent to the OS every frame using, for example, `path.is_file()`.
-#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "persistence", derive(serde::Deserialize, serde::Serialize))]
 pub struct DirectoryEntry {
     path: PathBuf,
     is_directory: bool,

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -53,18 +53,6 @@ impl Default for FileDialogStorage {
     }
 }
 
-// TODO: Either implement or remove before merge!
-
-// impl FileDialogStorage {
-//     pub fn load(ctx: &egui::Context, id: egui::Id) -> Self {
-//         ctx.data_mut(|d| d.get_persisted::<FileDialogStorage>(id).unwrap_or_default())
-//     }
-
-//     pub fn save(&self, ctx: &egui::Context, id: egui::Id) {
-//         ctx.data_mut(|d| d.insert_persisted(id, self.clone()));
-//     }
-// }
-
 /// Represents a file dialog instance.
 ///
 /// The `FileDialog` instance can be used multiple times and for different actions.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -37,7 +37,8 @@ pub enum DialogState {
 }
 
 /// Contains data of the FileDialog that should be stored persistently.
-#[derive(Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "persistence", derive(serde::Deserialize, serde::Serialize))]
 pub struct FileDialogStorage {
     /// The folders the user pinned to the left sidebar.
     pub pinned_folders: Vec<DirectoryEntry>,

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -37,7 +37,8 @@ pub enum DialogState {
 }
 
 /// Contains data of the FileDialog that should be stored persistently.
-struct FileDialogStorage {
+#[derive(Clone, serde::Deserialize, serde::Serialize)]
+pub struct FileDialogStorage {
     /// The folders the user pinned to the left sidebar.
     pub pinned_folders: Vec<DirectoryEntry>,
 }
@@ -50,6 +51,18 @@ impl Default for FileDialogStorage {
         }
     }
 }
+
+// TODO: Either implement or remove before merge!
+
+// impl FileDialogStorage {
+//     pub fn load(ctx: &egui::Context, id: egui::Id) -> Self {
+//         ctx.data_mut(|d| d.get_persisted::<FileDialogStorage>(id).unwrap_or_default())
+//     }
+
+//     pub fn save(&self, ctx: &egui::Context, id: egui::Id) {
+//         ctx.data_mut(|d| d.insert_persisted(id, self.clone()));
+//     }
+// }
 
 /// Represents a file dialog instance.
 ///
@@ -323,6 +336,11 @@ impl FileDialog {
 
     // -------------------------------------------------
     // Setter:
+
+    /// Mutably borrow internal storage.
+    pub fn storage_mut(&mut self) -> &mut FileDialogStorage {
+        &mut self.storage
+    }
 
     /// Overwrites the configuration of the file dialog.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,4 +161,4 @@ mod data;
 mod file_dialog;
 
 pub use config::{FileDialogConfig, FileDialogLabels};
-pub use file_dialog::{DialogMode, DialogState, FileDialog};
+pub use file_dialog::{DialogMode, DialogState, FileDialog, FileDialogStorage};


### PR DESCRIPTION
Implemented persistent storage with `FileDialog::storage_mut` to save and load the pinned folders.

This requires the new `persistence` feature, which implements `serde::Serialize` and `serde::Deserialize` for the objects to be saved.

Example:
```rust
struct MyApp {
    file_dialog: FileDialog,
}

impl MyApp {
    pub fn new(cc: &eframe::CreationContext) -> Self {
        let mut file_dialog = FileDialog::new();

        // Load the file dialog storage
        if let Some(storage) = cc.storage {
            *file_dialog.storage_mut() =
                 eframe::get_value(storage, "file_dialog_storage").unwrap_or_default()
        }

        Self {
            file_dialog,
        }
    }
}

impl eframe::App for MyApp {
    fn save(&mut self, storage: &mut dyn eframe::Storage) {
        // Save the file dialog storage
        eframe::set_value(storage, "file_dialog_storage", self.file_dialog.storage_mut());
    }
```

Ref: https://github.com/fluxxcode/egui-file-dialog/issues/42