### PR TITLE
Move storage to config and add builder methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased - v0.6.0
 ### ✨ Features
 - Added the ability to pin folders to the left sidebar and enable or disable the feature with `FileDialog::show_pinned_folders` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100)
-- Added `FileDialog::storage_mut` to be able to save and load the pinned folders [#104](https://github.com/fluxxcode/egui-file-dialog/pull/104)
+- Added `FileDialogConfig::storage`, `FileDialog::storage` and `FileDialog::storage_mut` to be able to save and load the pinned folders [#104](https://github.com/fluxxcode/egui-file-dialog/pull/104) and [#105](https://github.com/fluxxcode/egui-file-dialog/pull/105)
 
 ### ☢️ Deprecated
 - Deprecated `FileDialog::overwrite_config`. Use `FileDialog::with_config` and `FileDialog::config_mut` instead [#103](https://github.com/fluxxcode/egui-file-dialog/pull/103)

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::FileDialogStorage;
+
 /// Function that returns true if the specific item matches the filter.
 pub type Filter<T> = Arc<dyn Fn(&T) -> bool>;
 
@@ -90,6 +92,11 @@ impl QuickAccess {
 /// ```
 #[derive(Debug, Clone)]
 pub struct FileDialogConfig {
+    // ------------------------------------------------------------------------
+    // Core:
+    /// Persistent data of the file dialog.
+    pub storage: FileDialogStorage,
+
     // ------------------------------------------------------------------------
     // General options:
     /// The labels that the dialog uses.
@@ -191,6 +198,8 @@ impl Default for FileDialogConfig {
     /// Creates a new configuration with default values
     fn default() -> Self {
         Self {
+            storage: FileDialogStorage::default(),
+
             labels: FileDialogLabels::default(),
             initial_directory: std::env::current_dir().unwrap_or_default(),
             default_file_name: String::new(),
@@ -240,6 +249,14 @@ impl Default for FileDialogConfig {
 }
 
 impl FileDialogConfig {
+    /// Sets the storage used by the file dialog.
+    /// Storage includes all data that is persistently stored between multiple
+    /// file dialog instances.
+    pub fn storage(mut self, storage: FileDialogStorage) -> Self {
+        self.storage = storage;
+        self
+    }
+
     /// Sets a new icon for specific files or folders.
     ///
     /// # Arguments

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1236,7 +1236,14 @@ impl FileDialog {
     fn ui_update_pinned_paths(&mut self, ui: &mut egui::Ui, spacing: f32) -> bool {
         let mut visible = false;
 
-        for (i, path) in self.config.storage.pinned_folders.clone().iter().enumerate() {
+        for (i, path) in self
+            .config
+            .storage
+            .pinned_folders
+            .clone()
+            .iter()
+            .enumerate()
+        {
             if i == 0 {
                 ui.add_space(spacing);
                 ui.label(self.config.labels.heading_pinned.as_str());

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -37,7 +37,7 @@ pub enum DialogState {
 }
 
 /// Contains data of the FileDialog that should be stored persistently.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "persistence", derive(serde::Deserialize, serde::Serialize))]
 pub struct FileDialogStorage {
     /// The folders the user pinned to the left sidebar.
@@ -81,8 +81,6 @@ impl Default for FileDialogStorage {
 pub struct FileDialog {
     /// The configuration of the file dialog
     config: FileDialogConfig,
-    /// Persistent data of the file dialog
-    storage: FileDialogStorage,
 
     /// The mode the dialog is currently in
     mode: DialogMode,
@@ -159,7 +157,6 @@ impl FileDialog {
     pub fn new() -> Self {
         Self {
             config: FileDialogConfig::default(),
-            storage: FileDialogStorage::default(),
 
             mode: DialogMode::SelectDirectory,
             state: DialogState::Closed,
@@ -325,10 +322,17 @@ impl FileDialog {
 
     // -------------------------------------------------
     // Setter:
+    /// Sets the storage used by the file dialog.
+    /// Storage includes all data that is persistently stored between multiple
+    /// file dialog instances.
+    pub fn storage(mut self, storage: FileDialogStorage) -> Self {
+        self.config.storage = storage;
+        self
+    }
 
     /// Mutably borrow internal storage.
     pub fn storage_mut(&mut self) -> &mut FileDialogStorage {
-        &mut self.storage
+        &mut self.config.storage
     }
 
     /// Overwrites the configuration of the file dialog.
@@ -1232,7 +1236,7 @@ impl FileDialog {
     fn ui_update_pinned_paths(&mut self, ui: &mut egui::Ui, spacing: f32) -> bool {
         let mut visible = false;
 
-        for (i, path) in self.storage.pinned_folders.clone().iter().enumerate() {
+        for (i, path) in self.config.storage.pinned_folders.clone().iter().enumerate() {
             if i == 0 {
                 ui.add_space(spacing);
                 ui.label(self.config.labels.heading_pinned.as_str());
@@ -1661,17 +1665,17 @@ impl FileDialog {
 
     /// Pins a path to the left sidebar.
     fn pin_path(&mut self, path: DirectoryEntry) {
-        self.storage.pinned_folders.push(path);
+        self.config.storage.pinned_folders.push(path);
     }
 
     /// Unpins a path from the left sidebar.
     fn unpin_path(&mut self, path: &DirectoryEntry) {
-        self.storage.pinned_folders.retain(|p| p != path);
+        self.config.storage.pinned_folders.retain(|p| p != path);
     }
 
     /// Checks if the path is pinned to the left sidebar.
     fn is_pinned(&self, path: &DirectoryEntry) -> bool {
-        self.storage.pinned_folders.iter().any(|p| path == p)
+        self.config.storage.pinned_folders.iter().any(|p| path == p)
     }
 
     /// Resets the dialog to use default values.


### PR DESCRIPTION
Moved storage to `FileDialogConfig` and added methods `FileDialog::storage` and `FileDialogConfig::storage`.