### PR TITLE
Add option to overwrite a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### ✨ Features
 - Added the ability to pin folders to the left sidebar and enable or disable the feature with `FileDialog::show_pinned_folders` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100)
 - Added `FileDialogConfig::storage`, `FileDialog::storage` and `FileDialog::storage_mut` to be able to save and load the pinned folders [#104](https://github.com/fluxxcode/egui-file-dialog/pull/104) and [#105](https://github.com/fluxxcode/egui-file-dialog/pull/105)
+- Added new modal and option `FileDialog::allow_file_overwrite` to allow overwriting an already existing file when the dialog is in DialogMode::SaveFile mode [#106](https://github.com/fluxxcode/egui-file-dialog/pull/106)
 
 ### ☢️ Deprecated
 - Deprecated `FileDialog::overwrite_config`. Use `FileDialog::with_config` and `FileDialog::config_mut` instead [#103](https://github.com/fluxxcode/egui-file-dialog/pull/103)

--- a/examples/multilingual/src/main.rs
+++ b/examples/multilingual/src/main.rs
@@ -15,7 +15,7 @@ fn get_labels_german() -> FileDialogLabels {
         title_select_file: "📂 Datei Öffnen".to_string(),
         title_save_file: "📥 Datei Speichern".to_string(),
 
-        abort: "Abbrechen".to_string(),
+        cancel: "Abbrechen".to_string(),
         overwrite: "Überschreiben".to_string(),
 
         heading_pinned: "Angeheftet".to_string(),

--- a/examples/multilingual/src/main.rs
+++ b/examples/multilingual/src/main.rs
@@ -15,6 +15,9 @@ fn get_labels_german() -> FileDialogLabels {
         title_select_file: "📂 Datei Öffnen".to_string(),
         title_save_file: "📥 Datei Speichern".to_string(),
 
+        abort: "Abbrechen".to_string(),
+        overwrite: "Überschreiben".to_string(),
+
         heading_pinned: "Angeheftet".to_string(),
         heading_places: "Orte".to_string(),
         heading_devices: "Medien".to_string(),
@@ -38,6 +41,8 @@ fn get_labels_german() -> FileDialogLabels {
         open_button: "🗀  Öffnen".to_string(),
         save_button: "📥  Speichern".to_string(),
         cancel_button: "🚫 Abbrechen".to_string(),
+
+        overwrite_file_modal_text: "existiert bereits. Möchtest du es überschreiben?".to_string(),
 
         err_empty_folder_name: "Der Ordnername darf nicht leer sein".to_string(),
         err_empty_file_name: "Der Dateiname darf nicht leer sein".to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -351,8 +351,8 @@ pub struct FileDialogLabels {
     /// The default window title used when the dialog is in `DialogMode::SaveFile` mode.
     pub title_save_file: String,
 
-    /// Text displayed in the buttons to abort the current action.
-    pub abort: String,
+    /// Text displayed in the buttons to cancel the current action.
+    pub cancel: String,
     /// Text displayed in the buttons to overwrite something, such as a file.
     pub overwrite: String,
 
@@ -430,7 +430,7 @@ impl Default for FileDialogLabels {
             title_select_file: "📂 Open File".to_string(),
             title_save_file: "📥 Save File".to_string(),
 
-            abort: "Abort".to_string(),
+            cancel: "Cancel".to_string(),
             overwrite: "Overwrite".to_string(),
 
             heading_pinned: "Pinned".to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,6 +113,8 @@ pub struct FileDialogConfig {
 
     /// The icon that is used to display error messages.
     pub err_icon: String,
+    /// The icon that is used to display warning messages.
+    pub warn_icon: String,
     /// The default icon used to display files.
     pub default_file_icon: String,
     /// The default icon used to display folders.
@@ -207,6 +209,7 @@ impl Default for FileDialogConfig {
             canonicalize_paths: true,
 
             err_icon: String::from("⚠"),
+            warn_icon: String::from("⚠"),
             default_file_icon: String::from("🗋"),
             default_folder_icon: String::from("🗀"),
             pinned_icon: String::from("📌"),
@@ -348,6 +351,11 @@ pub struct FileDialogLabels {
     /// The default window title used when the dialog is in `DialogMode::SaveFile` mode.
     pub title_save_file: String,
 
+    /// Text displayed in the buttons to abort the current action.
+    pub abort: String,
+    /// Text displayed in the buttons to overwrite something, such as a file.
+    pub overwrite: String,
+
     // ------------------------------------------------------------------------
     // Left panel:
     /// Heading of the "Pinned" sections in the left panel
@@ -398,6 +406,11 @@ pub struct FileDialogLabels {
     pub cancel_button: String,
 
     // ------------------------------------------------------------------------
+    // Modal windows:
+    /// Text displayed after the path within the modal to overwrite the selected file.
+    pub overwrite_file_modal_text: String,
+
+    // ------------------------------------------------------------------------
     // Error message:
     /// Error if no folder name was specified.
     pub err_empty_folder_name: String,
@@ -416,6 +429,9 @@ impl Default for FileDialogLabels {
             title_select_directory: "📁 Select Folder".to_string(),
             title_select_file: "📂 Open File".to_string(),
             title_save_file: "📥 Save File".to_string(),
+
+            abort: "Abort".to_string(),
+            overwrite: "Overwrite".to_string(),
 
             heading_pinned: "Pinned".to_string(),
             heading_places: "Places".to_string(),
@@ -440,6 +456,8 @@ impl Default for FileDialogLabels {
             open_button: "🗀  Open".to_string(),
             save_button: "📥  Save".to_string(),
             cancel_button: "🚫 Cancel".to_string(),
+
+            overwrite_file_modal_text: "already exists. Do you want to overwrite it?".to_string(),
 
             err_empty_folder_name: "Name of the folder cannot be empty".to_string(),
             err_empty_file_name: "The file name cannot be empty".to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,6 +105,9 @@ pub struct FileDialogConfig {
     pub initial_directory: PathBuf,
     /// The default filename when opening the dialog in `DialogMode::SaveFile` mode.
     pub default_file_name: String,
+    /// If the user is allowed to select an already existing file when the dialog is
+    /// in `DialogMode::SaveFile` mode.
+    pub allow_file_overwrite: bool,
     /// Sets the separator of the directories when displaying a path.
     /// Currently only used when the current path is displayed in the top panel.
     pub directory_separator: String,
@@ -205,6 +208,7 @@ impl Default for FileDialogConfig {
             labels: FileDialogLabels::default(),
             initial_directory: std::env::current_dir().unwrap_or_default(),
             default_file_name: String::new(),
+            allow_file_overwrite: true,
             directory_separator: String::from(">"),
             canonicalize_paths: true,
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -448,6 +448,16 @@ impl FileDialog {
         self
     }
 
+    /// Sets if the user is allowed to select an already existing file when the dialog is in
+    /// `DialogMode::SaveFile` mode.
+    ///
+    /// If this is enabled, the user will receive a modal asking whether the user really
+    /// wants to overwrite an existing file.
+    pub fn allow_file_overwrite(mut self, allow_file_overwrite: bool) -> Self {
+        self.config.allow_file_overwrite = allow_file_overwrite;
+        self
+    }
+
     /// Sets the separator of the directories when displaying a path.
     /// Currently only used when the current path is displayed in the top panel.
     pub fn directory_separator(mut self, separator: &str) -> Self {
@@ -1843,6 +1853,10 @@ impl FileDialog {
 
             if full_path.is_dir() {
                 return Some(self.config.labels.err_directory_exists.clone());
+            }
+
+            if !self.config.allow_file_overwrite && full_path.is_file() {
+                return Some(self.config.labels.err_file_exists.clone());
             }
         } else {
             // There is most likely a bug in the code if we get this error message!

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -844,18 +844,18 @@ impl FileDialog {
         egui::TopBottomPanel::bottom("fe_modal_bottom_panel")
             .resizable(false)
             .show_separator_line(false)
-            .show_inside(ui, |_| { });
+            .show_inside(ui, |_| {});
 
         // We need to use a central panel for the modals so that the
         // window doesn't resize to the size of the modal.
         egui::CentralPanel::default().show_inside(ui, |ui| {
             if let Some(modal) = self.modals.last_mut() {
-                match modal.update(ui) {
+                match modal.update(&self.config, ui) {
                     ModalState::Close(action) => {
                         self.exec_modal_action(action);
                         self.modals.pop();
-                    },
-                    _ => {},
+                    }
+                    _ => {}
                 }
             }
         });
@@ -1508,6 +1508,7 @@ impl FileDialog {
 
                             if full_path.exists() {
                                 self.open_modal(Box::new(OverwriteFileModal::new(full_path)));
+
                                 return;
                             }
 
@@ -1711,7 +1712,7 @@ impl FileDialog {
     /// Executes the given modal action.
     fn exec_modal_action(&mut self, action: ModalAction) {
         match action {
-            ModalAction::None => {},
+            ModalAction::None => {}
             ModalAction::SaveFile(path) => self.finish(path),
         };
     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 use std::{fs, io};
 
 use egui::text::{CCursor, CCursorRange};
-use egui::Area;
 
 use crate::config::{FileDialogConfig, FileDialogLabels, Filter, QuickAccess};
 use crate::create_directory_dialog::CreateDirectoryDialog;

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -850,6 +850,7 @@ impl FileDialog {
         // window doesn't resize to the size of the modal.
         egui::CentralPanel::default().show_inside(ui, |ui| {
             if let Some(modal) = self.modals.last_mut() {
+                #[allow(clippy::single_match)]
                 match modal.update(&self.config, ui) {
                     ModalState::Close(action) => {
                         self.exec_modal_action(action);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@ mod config;
 mod create_directory_dialog;
 mod data;
 mod file_dialog;
+mod modals;
 
 pub use config::{FileDialogConfig, FileDialogLabels};
 pub use file_dialog::{DialogMode, DialogState, FileDialog, FileDialogStorage};

--- a/src/modals/mod.rs
+++ b/src/modals/mod.rs
@@ -1,0 +1,14 @@
+mod overwrite_file_modal;
+
+pub use overwrite_file_modal::OverwriteFileModal;
+
+pub enum ModalState {
+    // If the modal is currently open and still waiting for user input
+    Pending,
+    // If the modal should be closed in the next frame
+    Close
+}
+
+pub trait FileDialogModal {
+    fn update(&mut self, ui: &mut egui::Ui) -> ModalState;
+}

--- a/src/modals/mod.rs
+++ b/src/modals/mod.rs
@@ -4,17 +4,24 @@ mod overwrite_file_modal;
 
 pub use overwrite_file_modal::OverwriteFileModal;
 
+/// Contains actions that are executed by the file dialog when closing a modal.
 pub enum ModalAction {
+    /// If no action should be executed.
+    None,
+    /// If the file dialog should save the specified path.
+    /// Should only be used if the FileDialog is in `FileDialogMode::SaveFile` mode.
     SaveFile(PathBuf),
 }
 
 pub enum ModalState {
-    // If the modal is currently open and still waiting for user input
+    /// If the modal is currently open and still waiting for user input
     Pending,
-    // If the modal should be closed in the next frame
+    /// If the modal should be closed in the next frame
     Close(ModalAction),
 }
 
 pub trait FileDialogModal {
+    /// Main update method of the modal.
+    /// Should be called every time the modal should be visible.
     fn update(&mut self, ui: &mut egui::Ui) -> ModalState;
 }

--- a/src/modals/mod.rs
+++ b/src/modals/mod.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
-mod overwrite_file_modal;
+use crate::FileDialogConfig;
 
+mod overwrite_file_modal;
 pub use overwrite_file_modal::OverwriteFileModal;
 
 /// Contains actions that are executed by the file dialog when closing a modal.
@@ -23,5 +24,5 @@ pub enum ModalState {
 pub trait FileDialogModal {
     /// Main update method of the modal.
     /// Should be called every time the modal should be visible.
-    fn update(&mut self, ui: &mut egui::Ui) -> ModalState;
+    fn update(&mut self, config: &FileDialogConfig, ui: &mut egui::Ui) -> ModalState;
 }

--- a/src/modals/mod.rs
+++ b/src/modals/mod.rs
@@ -1,12 +1,18 @@
+use std::path::PathBuf;
+
 mod overwrite_file_modal;
 
 pub use overwrite_file_modal::OverwriteFileModal;
+
+pub enum ModalAction {
+    SaveFile(PathBuf),
+}
 
 pub enum ModalState {
     // If the modal is currently open and still waiting for user input
     Pending,
     // If the modal should be closed in the next frame
-    Close
+    Close(ModalAction),
 }
 
 pub trait FileDialogModal {

--- a/src/modals/overwrite_file_modal.rs
+++ b/src/modals/overwrite_file_modal.rs
@@ -1,0 +1,17 @@
+use super::{FileDialogModal, ModalState};
+
+pub struct OverwriteFileModal;
+
+impl OverwriteFileModal {
+    pub fn new() -> Self {
+        Self { }
+    }
+}
+
+impl FileDialogModal for OverwriteFileModal {
+    fn update(&mut self, ui: &mut egui::Ui) -> ModalState {
+        ui.label("Overwrite file modal");
+
+        ModalState::Pending
+    }
+}

--- a/src/modals/overwrite_file_modal.rs
+++ b/src/modals/overwrite_file_modal.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use super::{FileDialogModal, ModalAction, ModalState};
+use crate::config::FileDialogConfig;
 
 /// The modal that is used to ask the user if the selected path should be
 /// overwritten.
@@ -10,32 +11,74 @@ pub struct OverwriteFileModal {
 }
 
 impl OverwriteFileModal {
-    /// Creates a new modal objects.
-    /// 
+    /// Creates a new modal object.
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `path` - The path selected for overwriting.
     pub fn new(path: PathBuf) -> Self {
-        Self {
-            path,
-        }
+        Self { path }
     }
 }
 
 impl FileDialogModal for OverwriteFileModal {
-    fn update(&mut self, ui: &mut egui::Ui) -> ModalState {
-        // The UI is currently only used for testing purposes.
-        ui.label("Overwrite file modal");
-        ui.label(format!("Path: {:?}", self.path));
+    fn update(&mut self, config: &FileDialogConfig, ui: &mut egui::Ui) -> ModalState {
+        let mut return_val = ModalState::Pending;
 
-        if ui.button("Close").clicked() {
-            return ModalState::Close(ModalAction::None);
-        }
+        const SECTION_SPACING: f32 = 15.0;
+        const BUTTON_SIZE: egui::Vec2 = egui::Vec2::new(90.0, 20.0);
 
-        if ui.button("Save file").clicked() {
-            return ModalState::Close(ModalAction::SaveFile(self.path.clone()));
-        }
+        ui.vertical_centered(|ui| {
+            let warn_icon = egui::RichText::new(&config.warn_icon)
+                .color(ui.visuals().warn_fg_color)
+                .heading();
 
-        ModalState::Pending
+            ui.add_space(SECTION_SPACING);
+
+            ui.label(warn_icon);
+
+            ui.add_space(SECTION_SPACING);
+
+            // Used to wrap the path on a single line.
+            let mut job = egui::text::LayoutJob::single_section(
+                format!("'{}'", self.path.to_str().unwrap_or_default()),
+                egui::TextFormat::default(),
+            );
+
+            job.wrap = egui::text::TextWrapping {
+                max_rows: 1,
+                ..Default::default()
+            };
+
+            ui.label(job);
+            ui.label(&config.labels.overwrite_file_modal_text);
+
+            ui.add_space(SECTION_SPACING);
+
+            ui.horizontal(|ui| {
+                let required_width = BUTTON_SIZE.x * 2.0 + ui.style().spacing.item_spacing.x;
+                let padding = (ui.available_width() - required_width) / 2.0;
+
+                ui.add_space(padding);
+
+                if ui
+                    .add_sized(BUTTON_SIZE, egui::Button::new(&config.labels.abort))
+                    .clicked()
+                {
+                    return_val = ModalState::Close(ModalAction::None);
+                }
+
+                ui.add_space(ui.style().spacing.item_spacing.x);
+
+                if ui
+                    .add_sized(BUTTON_SIZE, egui::Button::new(&config.labels.overwrite))
+                    .clicked()
+                {
+                    return_val = ModalState::Close(ModalAction::SaveFile(self.path.to_path_buf()));
+                }
+            });
+        });
+
+        return_val
     }
 }

--- a/src/modals/overwrite_file_modal.rs
+++ b/src/modals/overwrite_file_modal.rs
@@ -1,16 +1,40 @@
-use super::{FileDialogModal, ModalState};
+use std::path::PathBuf;
 
-pub struct OverwriteFileModal;
+use super::{FileDialogModal, ModalAction, ModalState};
+
+/// The modal that is used to ask the user if the selected path should be
+/// overwritten.
+pub struct OverwriteFileModal {
+    /// The path selected for overwriting.
+    path: PathBuf,
+}
 
 impl OverwriteFileModal {
-    pub fn new() -> Self {
-        Self { }
+    /// Creates a new modal objects.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `path` - The path selected for overwriting.
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+        }
     }
 }
 
 impl FileDialogModal for OverwriteFileModal {
     fn update(&mut self, ui: &mut egui::Ui) -> ModalState {
+        // The UI is currently only used for testing purposes.
         ui.label("Overwrite file modal");
+        ui.label(format!("Path: {:?}", self.path));
+
+        if ui.button("Close").clicked() {
+            return ModalState::Close(ModalAction::None);
+        }
+
+        if ui.button("Save file").clicked() {
+            return ModalState::Close(ModalAction::SaveFile(self.path.clone()));
+        }
 
         ModalState::Pending
     }

--- a/src/modals/overwrite_file_modal.rs
+++ b/src/modals/overwrite_file_modal.rs
@@ -62,7 +62,7 @@ impl FileDialogModal for OverwriteFileModal {
                 ui.add_space(padding);
 
                 if ui
-                    .add_sized(BUTTON_SIZE, egui::Button::new(&config.labels.abort))
+                    .add_sized(BUTTON_SIZE, egui::Button::new(&config.labels.cancel))
                     .clicked()
                 {
                     return_val = ModalState::Close(ModalAction::None);


### PR DESCRIPTION
Added modal and option `FileDialog::allow_file_overwrite` to allow overwriting an already existing file when the dialog is in `DialogMode::SaveFile` mode.

Modal to ask the user if they really want to overwrite the existing file:
![Screenshot_20240515_194550](https://github.com/fluxxcode/egui-file-dialog/assets/55352293/7bad5ff2-f017-49ee-91b6-fb2c9da51113)

TODO:
- [x] Implement modal system inside the file dialog
- [x] Create modal to overwrite an existing file
- [x] Add a backend option to allow or disallow overwriting a file
- [x] Update `CHANGELOG.md`

Closes #101 