### PR TITLE
Persistence example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,16 @@
 ### ✨ Features
 - Added the ability to pin folders to the left sidebar and enable or disable the feature with `FileDialog::show_pinned_folders` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100)
 - Added `FileDialogConfig::storage`, `FileDialog::storage` and `FileDialog::storage_mut` to be able to save and load the pinned folders [#104](https://github.com/fluxxcode/egui-file-dialog/pull/104) and [#105](https://github.com/fluxxcode/egui-file-dialog/pull/105)
-- Added new modal and option `FileDialog::allow_file_overwrite` to allow overwriting an already existing file when the dialog is in DialogMode::SaveFile mode [#106](https://github.com/fluxxcode/egui-file-dialog/pull/106)
+- Added new modal and option `FileDialog::allow_file_overwrite` to allow overwriting an already existing file when the dialog is in `DialogMode::SaveFile` mode [#106](https://github.com/fluxxcode/egui-file-dialog/pull/106)
 
 ### ☢️ Deprecated
 - Deprecated `FileDialog::overwrite_config`. Use `FileDialog::with_config` and `FileDialog::config_mut` instead [#103](https://github.com/fluxxcode/egui-file-dialog/pull/103)
 
 ### 🐛 Bug Fixes
 - Fixed the size of the path edit input box and fixed an issue where the path edit would not close when clicking the apply button [#102](https://github.com/fluxxcode/egui-file-dialog/pull/102)
+
+### 📚 Documentation
+- Added `persistence` example showing how to save the persistent data of the file dialog [#107](https://github.com/fluxxcode/egui-file-dialog/pull/107)
 
 ## 2024-03-30 - v0.5.0 - egui update and QoL changes
 ### 🚨 Breaking Changes

--- a/examples/persistence/Cargo.toml
+++ b/examples/persistence/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "persistence"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+eframe = { version = "0.27.1", default-features = false, features = ["glow", "persistence"] }
+egui-file-dialog = { path = "../../" }

--- a/examples/persistence/README.md
+++ b/examples/persistence/README.md
@@ -1,0 +1,6 @@
+This example uses eframe to show how the persistent data of the file dialog can be saved. \
+If the default features of the file dialog are deactivated, the `persistence` feature must be enabled.
+
+```
+cargo run -p persistence
+```

--- a/examples/persistence/src/main.rs
+++ b/examples/persistence/src/main.rs
@@ -1,0 +1,67 @@
+use std::path::PathBuf;
+
+use eframe::egui;
+use egui_file_dialog::FileDialog;
+
+struct MyApp {
+    file_dialog: FileDialog,
+    selected_file: Option<PathBuf>,
+}
+
+impl MyApp {
+    pub fn new(cc: &eframe::CreationContext) -> Self {
+        let mut file_dialog = FileDialog::default();
+
+        // Load the persistent data of the file dialog.
+        // Alternatively, you can also use the `FileDialog::storage` builder method.
+        if let Some(storage) = cc.storage {
+            *file_dialog.storage_mut() =
+                eframe::get_value(storage, "file_dialog_storage").unwrap_or_default()
+        }
+
+        Self {
+            file_dialog,
+            selected_file: None,
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn save(&mut self, storage: &mut dyn eframe::Storage) {
+        // Save the persistent data of the file dialog
+        eframe::set_value(
+            storage,
+            "file_dialog_storage",
+            self.file_dialog.storage_mut(),
+        );
+    }
+
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            if ui.button("Select file").clicked() {
+                self.file_dialog.select_file();
+            }
+
+            ui.label(format!("Selected file: {:?}", self.selected_file));
+
+            self.file_dialog.update(ctx);
+
+            if let Some(path) = self.file_dialog.take_selected() {
+                self.selected_file = Some(path);
+            }
+        });
+    }
+}
+
+fn main() -> eframe::Result<()> {
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default().with_inner_size([1080.0, 720.0]),
+        ..Default::default()
+    };
+
+    eframe::run_native(
+        "My egui application",
+        options,
+        Box::new(|ctx| Box::new(MyApp::new(ctx))),
+    )
+}


### PR DESCRIPTION
Added `persistence` example showing how to save the persistent data of the file dialog.