### PR TITLE
Keyboard navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added the ability to pin folders to the left sidebar and enable or disable the feature with `FileDialog::show_pinned_folders` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100)
 - Added `FileDialogConfig::storage`, `FileDialog::storage` and `FileDialog::storage_mut` to be able to save and load the pinned folders [#104](https://github.com/fluxxcode/egui-file-dialog/pull/104) and [#105](https://github.com/fluxxcode/egui-file-dialog/pull/105)
 - Added new modal and option `FileDialog::allow_file_overwrite` to allow overwriting an already existing file when the dialog is in `DialogMode::SaveFile` mode [#106](https://github.com/fluxxcode/egui-file-dialog/pull/106)
+- Implemented customizable keyboard navigation using `FileDialogKeybindings` and `FileDialog::keybindings` [#110](https://github.com/fluxxcode/egui-file-dialog/pull/110)
 
 ### ☢️ Deprecated
 - Deprecated `FileDialog::overwrite_config`. Use `FileDialog::with_config` and `FileDialog::config_mut` instead [#103](https://github.com/fluxxcode/egui-file-dialog/pull/103)

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,8 @@ pub struct FileDialogConfig {
     // Core:
     /// Persistent data of the file dialog.
     pub storage: FileDialogStorage,
+    /// Keybindings used by the file dialog.
+    pub keybindings: KeyBindings,
 
     // ------------------------------------------------------------------------
     // General options:
@@ -204,6 +206,7 @@ impl Default for FileDialogConfig {
     fn default() -> Self {
         Self {
             storage: FileDialogStorage::default(),
+            keybindings: KeyBindings::default(),
 
             labels: FileDialogLabels::default(),
             initial_directory: std::env::current_dir().unwrap_or_default(),
@@ -320,6 +323,80 @@ impl FileDialogConfig {
         builder(&mut obj);
         self.quick_accesses.push(obj);
         self
+    }
+}
+
+/// Defines a keybinding used 
+#[derive(Debug, Clone)]
+pub enum KeyBinding {
+    /// If pointer buttons should be used as the keybinding
+    PointerButton(egui::PointerButton),
+    /// If a keyboard shortcut should be used as a keybinding
+    KeyboardShortcut(egui::KeyboardShortcut),
+}
+
+impl KeyBinding {
+    pub fn pointer_button(pointer_button: egui::PointerButton) -> Self {
+        Self::PointerButton(pointer_button)
+    }
+
+    pub fn keyboard_shortcut(modifiers: egui::Modifiers, logical_key: egui::Key) -> Self {
+        Self::KeyboardShortcut(egui::KeyboardShortcut {
+            modifiers,
+            logical_key,
+        })
+    }
+
+    pub fn key(logical_key: egui::Key) -> Self {
+        Self::KeyboardShortcut(egui::KeyboardShortcut {
+            modifiers: egui::Modifiers::NONE,
+            logical_key,
+        })
+    }
+}
+
+/// Stores the keybindings used for the file dialog.
+#[derive(Debug, Clone)]
+pub struct KeyBindings {
+    pub open_previous_directory: Vec<KeyBinding>,
+    pub search: Vec<KeyBinding>,
+}
+
+impl Default for KeyBindings {
+    fn default() -> Self {
+        use egui::{Key, PointerButton};
+
+        Self {
+            open_previous_directory: vec![KeyBinding::pointer_button(PointerButton::Extra1)],
+            search: vec![
+                KeyBinding::key(Key::A),
+                KeyBinding::key(Key::B),
+                KeyBinding::key(Key::C),
+                KeyBinding::key(Key::D),
+                KeyBinding::key(Key::E),
+                KeyBinding::key(Key::F),
+                KeyBinding::key(Key::G),
+                KeyBinding::key(Key::H),
+                KeyBinding::key(Key::I),
+                KeyBinding::key(Key::J),
+                KeyBinding::key(Key::K),
+                KeyBinding::key(Key::L),
+                KeyBinding::key(Key::M),
+                KeyBinding::key(Key::N),
+                KeyBinding::key(Key::O),
+                KeyBinding::key(Key::P),
+                KeyBinding::key(Key::Q),
+                KeyBinding::key(Key::R),
+                KeyBinding::key(Key::S),
+                KeyBinding::key(Key::T),
+                KeyBinding::key(Key::U),
+                KeyBinding::key(Key::V),
+                KeyBinding::key(Key::W),
+                KeyBinding::key(Key::X),
+                KeyBinding::key(Key::Y),
+                KeyBinding::key(Key::Z),
+            ],
+        }
     }
 }
 

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -41,7 +41,7 @@ impl KeyBinding {
 /// Stores the keybindings used for the file dialog.
 #[derive(Debug, Clone)]
 pub struct FileDialogKeyBindings {
-    /// Shortcut to submit the current action
+    /// Shortcut to submit the current action or enter the currently selected directory
     pub submit: Vec<KeyBinding>,
     /// Shortcut to cancel the current action
     pub cancel: Vec<KeyBinding>,
@@ -54,7 +54,7 @@ pub struct FileDialogKeyBindings {
     /// Shortcut to reload the file dialog
     pub reload: Vec<KeyBinding>,
     /// Shortcut to open the dialog to create a new folder
-    pub create_new_folder: Vec<KeyBinding>,
+    pub new_folder: Vec<KeyBinding>,
     /// Shortcut to text edit the current path
     pub edit_path: Vec<KeyBinding>,
 }
@@ -83,13 +83,14 @@ impl Default for FileDialogKeyBindings {
             back: vec![
                 KeyBinding::pointer_button(PointerButton::Extra1),
                 KeyBinding::keyboard_shortcut(Modifiers::ALT, Key::ArrowLeft),
+                KeyBinding::key(Key::Backspace),
             ],
             forward: vec![
                 KeyBinding::pointer_button(PointerButton::Extra2),
                 KeyBinding::keyboard_shortcut(Modifiers::ALT, Key::ArrowRight),
             ],
             reload: vec![KeyBinding::key(egui::Key::F5)],
-            create_new_folder: vec![KeyBinding::keyboard_shortcut(Modifiers::CTRL, Key::N)],
+            new_folder: vec![KeyBinding::keyboard_shortcut(Modifiers::CTRL, Key::N)],
             edit_path: vec![KeyBinding::key(Key::Slash)],
         }
     }

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -90,7 +90,7 @@ impl Default for FileDialogKeyBindings {
             ],
             reload: vec![KeyBinding::key(egui::Key::F5)],
             create_new_folder: vec![KeyBinding::keyboard_shortcut(Modifiers::CTRL, Key::N)],
-            edit_path: vec![KeyBinding::key(Key::Slash)]
+            edit_path: vec![KeyBinding::key(Key::Slash)],
         }
     }
 }

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -57,6 +57,10 @@ pub struct FileDialogKeyBindings {
     pub new_folder: Vec<KeyBinding>,
     /// Shortcut to text edit the current path
     pub edit_path: Vec<KeyBinding>,
+    /// Shortcut to move the selection one item up
+    pub selection_up: Vec<KeyBinding>,
+    /// Shortcut to move the selection one item down
+    pub selection_down: Vec<KeyBinding>,
 }
 
 impl FileDialogKeyBindings {
@@ -83,7 +87,6 @@ impl Default for FileDialogKeyBindings {
             back: vec![
                 KeyBinding::pointer_button(PointerButton::Extra1),
                 KeyBinding::keyboard_shortcut(Modifiers::ALT, Key::ArrowLeft),
-                KeyBinding::key(Key::Backspace),
             ],
             forward: vec![
                 KeyBinding::pointer_button(PointerButton::Extra2),
@@ -92,6 +95,8 @@ impl Default for FileDialogKeyBindings {
             reload: vec![KeyBinding::key(egui::Key::F5)],
             new_folder: vec![KeyBinding::keyboard_shortcut(Modifiers::CTRL, Key::N)],
             edit_path: vec![KeyBinding::key(Key::Slash)],
+            selection_up: vec![KeyBinding::key(Key::ArrowUp)],
+            selection_down: vec![KeyBinding::key(Key::ArrowDown)],
         }
     }
 }

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -5,7 +5,7 @@ pub enum KeyBinding {
     Key(egui::Key),
     /// If a keyboard shortcut should be used as a keybinding
     KeyboardShortcut(egui::KeyboardShortcut),
-    /// If pointer buttons should be used as the keybinding
+    /// If a pointer button should be used as the keybinding
     PointerButton(egui::PointerButton),
 }
 
@@ -41,8 +41,15 @@ impl KeyBinding {
 /// Stores the keybindings used for the file dialog.
 #[derive(Debug, Clone)]
 pub struct FileDialogKeyBindings {
+    /// Shortcut to open the parent directory
+    pub parent: Vec<KeyBinding>,
+    /// Shortcut to go back
     pub back: Vec<KeyBinding>,
+    /// Shortcut to go forward
     pub forward: Vec<KeyBinding>,
+    /// Shortcut to reload the file dialog
+    pub reload: Vec<KeyBinding>,
+    /// Shortcut to open the dialog to create a new folder
     pub create_new_folder: Vec<KeyBinding>,
 }
 
@@ -64,8 +71,16 @@ impl Default for FileDialogKeyBindings {
         use egui::{Key, Modifiers, PointerButton};
 
         Self {
-            back: vec![KeyBinding::pointer_button(PointerButton::Extra1)],
-            forward: vec![KeyBinding::pointer_button(PointerButton::Extra2)],
+            parent: vec![KeyBinding::keyboard_shortcut(Modifiers::ALT, Key::ArrowUp)],
+            back: vec![
+                KeyBinding::pointer_button(PointerButton::Extra1),
+                KeyBinding::keyboard_shortcut(Modifiers::ALT, Key::ArrowLeft),
+            ],
+            forward: vec![
+                KeyBinding::pointer_button(PointerButton::Extra2),
+                KeyBinding::keyboard_shortcut(Modifiers::ALT, Key::ArrowRight),
+            ],
+            reload: vec![KeyBinding::key(egui::Key::F5)],
             create_new_folder: vec![KeyBinding::keyboard_shortcut(Modifiers::CTRL, Key::N)],
         }
     }

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -41,6 +41,10 @@ impl KeyBinding {
 /// Stores the keybindings used for the file dialog.
 #[derive(Debug, Clone)]
 pub struct FileDialogKeyBindings {
+    /// Shortcut to submit the current action
+    pub submit: Vec<KeyBinding>,
+    /// Shortcut to cancel the current action
+    pub cancel: Vec<KeyBinding>,
     /// Shortcut to open the parent directory
     pub parent: Vec<KeyBinding>,
     /// Shortcut to go back
@@ -71,6 +75,8 @@ impl Default for FileDialogKeyBindings {
         use egui::{Key, Modifiers, PointerButton};
 
         Self {
+            submit: vec![KeyBinding::key(Key::Enter)],
+            cancel: vec![KeyBinding::key(Key::Escape)],
             parent: vec![KeyBinding::keyboard_shortcut(Modifiers::ALT, Key::ArrowUp)],
             back: vec![
                 KeyBinding::pointer_button(PointerButton::Extra1),

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -1,0 +1,73 @@
+/// Defines a keybinding used for a specific action inside the file dialog.
+#[derive(Debug, Clone)]
+pub enum KeyBinding {
+    /// If pointer buttons should be used as the keybinding
+    PointerButton(egui::PointerButton),
+    /// If a keyboard shortcut should be used as a keybinding
+    KeyboardShortcut(egui::KeyboardShortcut),
+}
+
+impl KeyBinding {
+    pub fn pointer_button(pointer_button: egui::PointerButton) -> Self {
+        Self::PointerButton(pointer_button)
+    }
+
+    pub fn keyboard_shortcut(modifiers: egui::Modifiers, logical_key: egui::Key) -> Self {
+        Self::KeyboardShortcut(egui::KeyboardShortcut {
+            modifiers,
+            logical_key,
+        })
+    }
+
+    pub fn key(logical_key: egui::Key) -> Self {
+        Self::KeyboardShortcut(egui::KeyboardShortcut {
+            modifiers: egui::Modifiers::NONE,
+            logical_key,
+        })
+    }
+}
+
+/// Stores the keybindings used for the file dialog.
+#[derive(Debug, Clone)]
+pub struct KeyBindings {
+    pub open_previous_directory: Vec<KeyBinding>,
+    pub search: Vec<KeyBinding>,
+}
+
+impl Default for KeyBindings {
+    fn default() -> Self {
+        use egui::{Key, PointerButton};
+
+        Self {
+            open_previous_directory: vec![KeyBinding::pointer_button(PointerButton::Extra1)],
+            search: vec![
+                KeyBinding::key(Key::A),
+                KeyBinding::key(Key::B),
+                KeyBinding::key(Key::C),
+                KeyBinding::key(Key::D),
+                KeyBinding::key(Key::E),
+                KeyBinding::key(Key::F),
+                KeyBinding::key(Key::G),
+                KeyBinding::key(Key::H),
+                KeyBinding::key(Key::I),
+                KeyBinding::key(Key::J),
+                KeyBinding::key(Key::K),
+                KeyBinding::key(Key::L),
+                KeyBinding::key(Key::M),
+                KeyBinding::key(Key::N),
+                KeyBinding::key(Key::O),
+                KeyBinding::key(Key::P),
+                KeyBinding::key(Key::Q),
+                KeyBinding::key(Key::R),
+                KeyBinding::key(Key::S),
+                KeyBinding::key(Key::T),
+                KeyBinding::key(Key::U),
+                KeyBinding::key(Key::V),
+                KeyBinding::key(Key::W),
+                KeyBinding::key(Key::X),
+                KeyBinding::key(Key::Y),
+                KeyBinding::key(Key::Z),
+            ],
+        }
+    }
+}

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -90,10 +90,7 @@ impl Default for FileDialogKeyBindings {
             ],
             reload: vec![KeyBinding::key(egui::Key::F5)],
             create_new_folder: vec![KeyBinding::keyboard_shortcut(Modifiers::CTRL, Key::N)],
-            edit_path: vec![
-                KeyBinding::key(Key::Slash),
-                KeyBinding::key(Key::Backslash),
-            ]
+            edit_path: vec![KeyBinding::key(Key::Slash)]
         }
     }
 }

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -1,16 +1,18 @@
 /// Defines a keybinding used for a specific action inside the file dialog.
 #[derive(Debug, Clone)]
 pub enum KeyBinding {
-    /// If pointer buttons should be used as the keybinding
-    PointerButton(egui::PointerButton),
+    /// If a single key should be used as a keybinding
+    Key(egui::Key),
     /// If a keyboard shortcut should be used as a keybinding
     KeyboardShortcut(egui::KeyboardShortcut),
+    /// If pointer buttons should be used as the keybinding
+    PointerButton(egui::PointerButton),
 }
 
 impl KeyBinding {
-    /// Creates a new keybinding where a pointer button is used.
-    pub fn pointer_button(pointer_button: egui::PointerButton) -> Self {
-        Self::PointerButton(pointer_button)
+    /// Creates a new keybinding where a single key is used.
+    pub fn key(key: egui::Key) -> Self {
+        Self::Key(key)
     }
 
     /// Creates a new keybinding where a keyboard shortcut is used.
@@ -21,19 +23,17 @@ impl KeyBinding {
         })
     }
 
-    /// Create a new keybinding where a single key is used.
-    pub fn key(logical_key: egui::Key) -> Self {
-        Self::KeyboardShortcut(egui::KeyboardShortcut {
-            modifiers: egui::Modifiers::NONE,
-            logical_key,
-        })
+    /// Creates a new keybinding where a pointer button is used.
+    pub fn pointer_button(pointer_button: egui::PointerButton) -> Self {
+        Self::PointerButton(pointer_button)
     }
 
     /// Checks if the keybinding was pressed by the user.
     pub fn pressed(&self, ctx: &egui::Context) -> bool {
         match self {
-            KeyBinding::PointerButton(b) => ctx.input(|i| i.pointer.button_clicked(*b)),
+            KeyBinding::Key(k) => ctx.input(|i| i.key_pressed(*k)),
             KeyBinding::KeyboardShortcut(s) => ctx.input_mut(|i| i.consume_shortcut(s)),
+            KeyBinding::PointerButton(b) => ctx.input(|i| i.pointer.button_clicked(*b)),
         }
     }
 }
@@ -41,8 +41,8 @@ impl KeyBinding {
 /// Stores the keybindings used for the file dialog.
 #[derive(Debug, Clone)]
 pub struct FileDialogKeyBindings {
-    pub open_previous_directory: Vec<KeyBinding>,
-    pub open_next_directory: Vec<KeyBinding>,
+    pub back: Vec<KeyBinding>,
+    pub forward: Vec<KeyBinding>,
     pub create_new_folder: Vec<KeyBinding>,
 }
 
@@ -64,8 +64,8 @@ impl Default for FileDialogKeyBindings {
         use egui::{Key, Modifiers, PointerButton};
 
         Self {
-            open_previous_directory: vec![KeyBinding::pointer_button(PointerButton::Extra1)],
-            open_next_directory: vec![KeyBinding::pointer_button(PointerButton::Extra2)],
+            back: vec![KeyBinding::pointer_button(PointerButton::Extra1)],
+            forward: vec![KeyBinding::pointer_button(PointerButton::Extra2)],
             create_new_folder: vec![KeyBinding::keyboard_shortcut(Modifiers::CTRL, Key::N)],
         }
     }

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -8,10 +8,12 @@ pub enum KeyBinding {
 }
 
 impl KeyBinding {
+    /// Creates a new keybinding where a pointer button is used.
     pub fn pointer_button(pointer_button: egui::PointerButton) -> Self {
         Self::PointerButton(pointer_button)
     }
 
+    /// Creates a new keybinding where a pointer button is used.
     pub fn keyboard_shortcut(modifiers: egui::Modifiers, logical_key: egui::Key) -> Self {
         Self::KeyboardShortcut(egui::KeyboardShortcut {
             modifiers,
@@ -19,55 +21,52 @@ impl KeyBinding {
         })
     }
 
+    /// Create a new keybinding where a single key is used.
     pub fn key(logical_key: egui::Key) -> Self {
         Self::KeyboardShortcut(egui::KeyboardShortcut {
             modifiers: egui::Modifiers::NONE,
             logical_key,
         })
     }
+
+    /// Checks if the keybinding was pressed by the user.
+    pub fn pressed(&self, ctx: &egui::Context) -> bool {
+        match self {
+            KeyBinding::PointerButton(b) => ctx.input(|i| i.pointer.button_clicked(*b)),
+            KeyBinding::KeyboardShortcut(s) => ctx.input_mut(|i| i.consume_shortcut(s)),
+        }
+    }
 }
 
 /// Stores the keybindings used for the file dialog.
 #[derive(Debug, Clone)]
-pub struct KeyBindings {
+pub struct FileDialogKeyBindings {
     pub open_previous_directory: Vec<KeyBinding>,
-    pub search: Vec<KeyBinding>,
+    pub open_next_directory: Vec<KeyBinding>,
+    pub create_new_folder: Vec<KeyBinding>,
 }
 
-impl Default for KeyBindings {
+impl FileDialogKeyBindings {
+    /// Checks wether any of the given keybindings is pressed.
+    pub fn any_pressed(ctx: &egui::Context, keybindings: &Vec<KeyBinding>) -> bool {
+        for keybinding in keybindings {
+            if keybinding.pressed(ctx) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+impl Default for FileDialogKeyBindings {
     fn default() -> Self {
-        use egui::{Key, PointerButton};
+        use egui::{Key, Modifiers, PointerButton};
 
         Self {
             open_previous_directory: vec![KeyBinding::pointer_button(PointerButton::Extra1)],
-            search: vec![
-                KeyBinding::key(Key::A),
-                KeyBinding::key(Key::B),
-                KeyBinding::key(Key::C),
-                KeyBinding::key(Key::D),
-                KeyBinding::key(Key::E),
-                KeyBinding::key(Key::F),
-                KeyBinding::key(Key::G),
-                KeyBinding::key(Key::H),
-                KeyBinding::key(Key::I),
-                KeyBinding::key(Key::J),
-                KeyBinding::key(Key::K),
-                KeyBinding::key(Key::L),
-                KeyBinding::key(Key::M),
-                KeyBinding::key(Key::N),
-                KeyBinding::key(Key::O),
-                KeyBinding::key(Key::P),
-                KeyBinding::key(Key::Q),
-                KeyBinding::key(Key::R),
-                KeyBinding::key(Key::S),
-                KeyBinding::key(Key::T),
-                KeyBinding::key(Key::U),
-                KeyBinding::key(Key::V),
-                KeyBinding::key(Key::W),
-                KeyBinding::key(Key::X),
-                KeyBinding::key(Key::Y),
-                KeyBinding::key(Key::Z),
-            ],
+            open_next_directory: vec![KeyBinding::pointer_button(PointerButton::Extra2)],
+            create_new_folder: vec![KeyBinding::keyboard_shortcut(Modifiers::CTRL, Key::N)],
         }
     }
 }

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -30,6 +30,12 @@ impl KeyBinding {
 
     /// Checks if the keybinding was pressed by the user.
     pub fn pressed(&self, ctx: &egui::Context) -> bool {
+        // We want to suppress keyboard input when any other widget like
+        // text fields have focus.
+        if ctx.memory(|r| r.focused()).is_some() {
+            return false;
+        }
+
         match self {
             KeyBinding::Key(k) => ctx.input(|i| i.key_pressed(*k)),
             KeyBinding::KeyboardShortcut(s) => ctx.input_mut(|i| i.consume_shortcut(s)),

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -55,6 +55,8 @@ pub struct FileDialogKeyBindings {
     pub reload: Vec<KeyBinding>,
     /// Shortcut to open the dialog to create a new folder
     pub create_new_folder: Vec<KeyBinding>,
+    /// Shortcut to text edit the current path
+    pub edit_path: Vec<KeyBinding>,
 }
 
 impl FileDialogKeyBindings {
@@ -88,6 +90,10 @@ impl Default for FileDialogKeyBindings {
             ],
             reload: vec![KeyBinding::key(egui::Key::F5)],
             create_new_folder: vec![KeyBinding::keyboard_shortcut(Modifiers::CTRL, Key::N)],
+            edit_path: vec![
+                KeyBinding::key(Key::Slash),
+                KeyBinding::key(Key::Backslash),
+            ]
         }
     }
 }

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -13,7 +13,7 @@ impl KeyBinding {
         Self::PointerButton(pointer_button)
     }
 
-    /// Creates a new keybinding where a pointer button is used.
+    /// Creates a new keybinding where a keyboard shortcut is used.
     pub fn keyboard_shortcut(modifiers: egui::Modifiers, logical_key: egui::Key) -> Self {
         Self::KeyboardShortcut(egui::KeyboardShortcut {
             modifiers,

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -93,6 +93,7 @@ impl Default for FileDialogKeyBindings {
             back: vec![
                 KeyBinding::pointer_button(PointerButton::Extra1),
                 KeyBinding::keyboard_shortcut(Modifiers::ALT, Key::ArrowLeft),
+                KeyBinding::key(Key::Backspace),
             ],
             forward: vec![
                 KeyBinding::pointer_button(PointerButton::Extra2),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,6 +1,9 @@
 mod labels;
 pub use labels::FileDialogLabels;
 
+mod keybindings;
+pub use keybindings::KeyBindings;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -269,80 +272,6 @@ impl FileDialogConfig {
         builder(&mut obj);
         self.quick_accesses.push(obj);
         self
-    }
-}
-
-/// Defines a keybinding used 
-#[derive(Debug, Clone)]
-pub enum KeyBinding {
-    /// If pointer buttons should be used as the keybinding
-    PointerButton(egui::PointerButton),
-    /// If a keyboard shortcut should be used as a keybinding
-    KeyboardShortcut(egui::KeyboardShortcut),
-}
-
-impl KeyBinding {
-    pub fn pointer_button(pointer_button: egui::PointerButton) -> Self {
-        Self::PointerButton(pointer_button)
-    }
-
-    pub fn keyboard_shortcut(modifiers: egui::Modifiers, logical_key: egui::Key) -> Self {
-        Self::KeyboardShortcut(egui::KeyboardShortcut {
-            modifiers,
-            logical_key,
-        })
-    }
-
-    pub fn key(logical_key: egui::Key) -> Self {
-        Self::KeyboardShortcut(egui::KeyboardShortcut {
-            modifiers: egui::Modifiers::NONE,
-            logical_key,
-        })
-    }
-}
-
-/// Stores the keybindings used for the file dialog.
-#[derive(Debug, Clone)]
-pub struct KeyBindings {
-    pub open_previous_directory: Vec<KeyBinding>,
-    pub search: Vec<KeyBinding>,
-}
-
-impl Default for KeyBindings {
-    fn default() -> Self {
-        use egui::{Key, PointerButton};
-
-        Self {
-            open_previous_directory: vec![KeyBinding::pointer_button(PointerButton::Extra1)],
-            search: vec![
-                KeyBinding::key(Key::A),
-                KeyBinding::key(Key::B),
-                KeyBinding::key(Key::C),
-                KeyBinding::key(Key::D),
-                KeyBinding::key(Key::E),
-                KeyBinding::key(Key::F),
-                KeyBinding::key(Key::G),
-                KeyBinding::key(Key::H),
-                KeyBinding::key(Key::I),
-                KeyBinding::key(Key::J),
-                KeyBinding::key(Key::K),
-                KeyBinding::key(Key::L),
-                KeyBinding::key(Key::M),
-                KeyBinding::key(Key::N),
-                KeyBinding::key(Key::O),
-                KeyBinding::key(Key::P),
-                KeyBinding::key(Key::Q),
-                KeyBinding::key(Key::R),
-                KeyBinding::key(Key::S),
-                KeyBinding::key(Key::T),
-                KeyBinding::key(Key::U),
-                KeyBinding::key(Key::V),
-                KeyBinding::key(Key::W),
-                KeyBinding::key(Key::X),
-                KeyBinding::key(Key::Y),
-                KeyBinding::key(Key::Z),
-            ],
-        }
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,7 +8,24 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::FileDialogStorage;
+use crate::data::DirectoryEntry;
+
+/// Contains data of the FileDialog that should be stored persistently.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "persistence", derive(serde::Deserialize, serde::Serialize))]
+pub struct FileDialogStorage {
+    /// The folders the user pinned to the left sidebar.
+    pub pinned_folders: Vec<DirectoryEntry>,
+}
+
+impl Default for FileDialogStorage {
+    /// Creates a new object with default values
+    fn default() -> Self {
+        Self {
+            pinned_folders: Vec::new(),
+        }
+    }
+}
 
 /// Contains configuration values of a file dialog.
 ///

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,7 +2,7 @@ mod labels;
 pub use labels::FileDialogLabels;
 
 mod keybindings;
-pub use keybindings::KeyBindings;
+pub use keybindings::FileDialogKeyBindings;
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -46,7 +46,7 @@ pub struct FileDialogConfig {
     /// Persistent data of the file dialog.
     pub storage: FileDialogStorage,
     /// Keybindings used by the file dialog.
-    pub keybindings: KeyBindings,
+    pub keybindings: FileDialogKeyBindings,
 
     // ------------------------------------------------------------------------
     // General options:
@@ -155,7 +155,7 @@ impl Default for FileDialogConfig {
     fn default() -> Self {
         Self {
             storage: FileDialogStorage::default(),
-            keybindings: KeyBindings::default(),
+            keybindings: FileDialogKeyBindings::default(),
 
             labels: FileDialogLabels::default(),
             initial_directory: std::env::current_dir().unwrap_or_default(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,7 +2,7 @@ mod labels;
 pub use labels::FileDialogLabels;
 
 mod keybindings;
-pub use keybindings::FileDialogKeyBindings;
+pub use keybindings::{FileDialogKeyBindings, KeyBinding};
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -298,15 +298,20 @@ impl std::fmt::Debug for IconFilter {
 /// Stores the display name and the actual path of a quick access link.
 #[derive(Debug, Clone)]
 pub struct QuickAccessPath {
+    /// Name of the path that is shown inside the left panel.
     pub display_name: String,
+    /// Absolute or relative path to the folder.
     pub path: PathBuf,
 }
 
 /// Stores a custom quick access section of the file dialog.
 #[derive(Debug, Clone)]
 pub struct QuickAccess {
-    pub canonicalize_paths: bool,
+    /// If the path's inside the quick access section should be canonicalized.
+    canonicalize_paths: bool,
+    /// Name of the quick access section displayed inside the left panel.
     pub heading: String,
+    /// Path's contained inside the quick access section.
     pub paths: Vec<QuickAccessPath>,
 }
 

--- a/src/create_directory_dialog.rs
+++ b/src/create_directory_dialog.rs
@@ -93,11 +93,11 @@ impl CreateDirectoryDialog {
         ui.horizontal(|ui| {
             ui.label(&config.default_folder_icon);
 
-            let response = ui.text_edit_singleline(&mut self.input);
+            let text_edit_response = ui.text_edit_singleline(&mut self.input);
 
             if self.init {
-                response.scroll_to_me(Some(egui::Align::Center));
-                response.request_focus();
+                text_edit_response.scroll_to_me(Some(egui::Align::Center));
+                text_edit_response.request_focus();
 
                 self.error = self.validate_input(&config.labels);
                 self.init = false;
@@ -105,15 +105,27 @@ impl CreateDirectoryDialog {
             }
 
             if self.request_focus {
-                response.request_focus();
+                text_edit_response.request_focus();
                 self.request_focus = false;
             }
 
-            if response.changed() {
+            if text_edit_response.changed() {
                 self.error = self.validate_input(&config.labels);
             }
 
-            if response.lost_focus() && ui.ctx().input(|input| input.key_pressed(egui::Key::Enter))
+            let apply_button_response =
+                ui.add_enabled(self.error.is_none(), egui::Button::new("✔"));
+
+            if apply_button_response.clicked() {
+                result = self.create_directory();
+            }
+
+            if ui.button("✖").clicked() {
+                self.close();
+            }
+
+            if text_edit_response.lost_focus()
+                && ui.ctx().input(|input| input.key_pressed(egui::Key::Enter))
             {
                 // Only necessary in the event of an error
                 self.request_focus = true;
@@ -121,18 +133,7 @@ impl CreateDirectoryDialog {
                 if self.error.is_none() {
                     result = self.create_directory();
                 }
-            } else if response.lost_focus() {
-                self.close();
-            }
-
-            if ui
-                .add_enabled(self.error.is_none(), egui::Button::new("✔"))
-                .clicked()
-            {
-                result = self.create_directory();
-            }
-
-            if ui.button("✖").clicked() {
+            } else if text_edit_response.lost_focus() && !apply_button_response.contains_pointer() {
                 self.close();
             }
         });

--- a/src/create_directory_dialog.rs
+++ b/src/create_directory_dialog.rs
@@ -113,7 +113,8 @@ impl CreateDirectoryDialog {
                 self.error = self.validate_input(&config.labels);
             }
 
-            if response.lost_focus() && ui.ctx().input(|input| input.key_pressed(egui::Key::Enter)) {
+            if response.lost_focus() && ui.ctx().input(|input| input.key_pressed(egui::Key::Enter))
+            {
                 // Only necessary in the event of an error
                 self.request_focus = true;
 

--- a/src/create_directory_dialog.rs
+++ b/src/create_directory_dialog.rs
@@ -69,9 +69,14 @@ impl CreateDirectoryDialog {
         self.directory = Some(directory);
     }
 
-    /// Closes and resets the dialog.
+    /// Closes and resets the dialog without creating the directory.
     pub fn close(&mut self) {
         self.reset();
+    }
+
+    /// Triggers the action to create the folder with the given name.
+    pub fn submit(&mut self) -> CreateDirectoryResponse {
+        self.create_directory()
     }
 
     /// Main update function of the dialog. Should be called in every frame

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -150,6 +150,11 @@ impl DirectoryContent {
     pub fn push(&mut self, item: DirectoryEntry) {
         self.content.push(item);
     }
+
+    /// Clears the items inside the directory.
+    pub fn clear(&mut self) {
+        self.content.clear();
+    }
 }
 
 /// Loads the contents of the given directory.

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -126,6 +126,21 @@ impl DirectoryContent {
         self.content.iter()
     }
 
+    /// Gets the item at the specified index.
+    pub fn get(&self, index: usize) -> Option<&DirectoryEntry> {
+        self.content.get(index)
+    }
+
+    /// Gets the last item inside the directory.
+    pub fn last(&self) -> Option<&DirectoryEntry> {
+        self.content.last()
+    }
+
+    /// Gets the first item inside the directory.
+    pub fn first(&self) -> Option<&DirectoryEntry> {
+        self.content.first()
+    }
+
     /// Returns the number of elements inside the directory.
     pub fn len(&self) -> usize {
         self.content.len()

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -120,25 +120,27 @@ impl DirectoryContent {
         })
     }
 
-    /// Very simple wrapper methods of the contents .iter() method.
-    /// No trait is implemented since this is currently only used internal.
-    pub fn iter(&self) -> std::slice::Iter<'_, DirectoryEntry> {
-        self.content.iter()
+    /// Checks if the given directory entry is visible with the applied filters.
+    fn is_entry_visible(dir_entry: &DirectoryEntry, search_value: &str) -> bool {
+        if !search_value.is_empty()
+            && !dir_entry
+                .file_name()
+                .to_lowercase()
+                .contains(&search_value.to_lowercase())
+        {
+            return false;
+        }
+
+        true
     }
 
-    /// Gets the item at the specified index.
-    pub fn get(&self, index: usize) -> Option<&DirectoryEntry> {
-        self.content.get(index)
-    }
-
-    /// Gets the last item inside the directory.
-    pub fn last(&self) -> Option<&DirectoryEntry> {
-        self.content.last()
-    }
-
-    /// Gets the first item inside the directory.
-    pub fn first(&self) -> Option<&DirectoryEntry> {
-        self.content.first()
+    pub fn filtered_iter<'s>(
+        &'s self,
+        search_value: &'s str,
+    ) -> impl Iterator<Item = &DirectoryEntry> + 's {
+        self.content
+            .iter()
+            .filter(|p| Self::is_entry_visible(p, search_value))
     }
 
     /// Returns the number of elements inside the directory.

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -126,6 +126,11 @@ impl DirectoryContent {
         self.content.iter()
     }
 
+    /// Returns the number of elements inside the directory.
+    pub fn len(&self) -> usize {
+        self.content.len()
+    }
+
     /// Pushes a new item to the content.
     pub fn push(&mut self, item: DirectoryEntry) {
         self.content.push(item);

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -366,19 +366,6 @@ impl FileDialog {
 
     // -------------------------------------------------
     // Setter:
-    /// Sets the storage used by the file dialog.
-    /// Storage includes all data that is persistently stored between multiple
-    /// file dialog instances.
-    pub fn storage(mut self, storage: FileDialogStorage) -> Self {
-        self.config.storage = storage;
-        self
-    }
-
-    /// Mutably borrow internal storage.
-    pub fn storage_mut(&mut self) -> &mut FileDialogStorage {
-        &mut self.config.storage
-    }
-
     /// Overwrites the configuration of the file dialog.
     ///
     /// This is useful when you want to configure multiple `FileDialog` objects with the
@@ -449,6 +436,25 @@ impl FileDialog {
     /// Mutably borrow internal `config`.
     pub fn config_mut(&mut self) -> &mut FileDialogConfig {
         &mut self.config
+    }
+
+    /// Sets the storage used by the file dialog.
+    /// Storage includes all data that is persistently stored between multiple
+    /// file dialog instances.
+    pub fn storage(mut self, storage: FileDialogStorage) -> Self {
+        self.config.storage = storage;
+        self
+    }
+
+    /// Mutably borrow internal storage.
+    pub fn storage_mut(&mut self) -> &mut FileDialogStorage {
+        &mut self.config.storage
+    }
+
+    /// Sets the keybindings used by the file dialog.
+    pub fn keybindings(mut self, keybindings: FileDialogKeyBindings) -> Self {
+        self.config.keybindings = keybindings;
+        self
     }
 
     /// Sets the labels the file dialog uses.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1720,39 +1720,27 @@ impl FileDialog {
             self.exec_keybinding_cancel();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.parent)
-            && self.config.show_parent_button
-        {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.parent) {
             let _ = self.load_parent_directory();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.back)
-            && self.config.show_back_button
-        {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.back) {
             let _ = self.load_previous_directory();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.forward)
-            && self.config.show_forward_button
-        {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.forward) {
             let _ = self.load_next_directory();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.reload)
-            && self.config.show_reload_button
-        {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.reload) {
             self.refresh();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.new_folder)
-            && self.config.show_new_folder_button
-        {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.new_folder) {
             self.open_new_folder_dialog();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.edit_path)
-            && self.config.show_path_edit_button
-        {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.edit_path) {
             self.open_path_edit();
         }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1737,7 +1737,7 @@ impl FileDialog {
         }
 
         if FileDialogKeyBindings::any_pressed(ctx, &keybindings.parent)
-            && self.config.show_back_button
+            && self.config.show_parent_button
         {
             let _ = self.load_parent_directory();
         }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1775,8 +1775,7 @@ impl FileDialog {
             let is_visible = self
                 .directory_content
                 .filtered_iter(&self.search_value)
-                .position(|p| p == item)
-                .is_some();
+                .any(|p| p == item);
 
             if is_visible && item.is_dir() {
                 let _ = self.load_directory(&item.to_path_buf());

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1146,8 +1146,11 @@ impl FileDialog {
             self.submit_path_edit(true);
         }
 
-        if !response.has_focus() && !btn_response.contains_pointer() {
-            self.close_path_edit();
+        if response.lost_focus() && ui.ctx().input(|input| input.key_pressed(egui::Key::Enter)) {
+            self.path_edit_request_focus = true;
+            self.submit_path_edit(false);
+        } else if !response.has_focus() && !btn_response.contains_pointer() {
+            self.path_edit_visible = false;
         }
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1731,6 +1731,12 @@ impl FileDialog {
             self.open_new_folder_dialog();
         }
 
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.edit_path)
+            && self.config.show_new_folder_button
+        {
+            self.open_path_edit();
+        }
+
         self.config.keybindings = keybindings;
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1725,7 +1725,7 @@ impl FileDialog {
             self.refresh();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.create_new_folder)
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.new_folder)
             && self.config.show_new_folder_button
         {
             self.open_new_folder_dialog();

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2184,8 +2184,6 @@ impl FileDialog {
     /// nothing changes.
     /// Otherwise, the result of the directory loading operation is returned.
     fn load_next_directory(&mut self) -> io::Result<()> {
-        self.close_path_edit();
-
         if self.directory_offset == 0 {
             // There is no next directory that can be loaded
             return Ok(());
@@ -2205,8 +2203,6 @@ impl FileDialog {
     /// If there is no previous directory left, Ok() is returned and nothing changes.
     /// Otherwise, the result of the directory loading operation is returned.
     fn load_previous_directory(&mut self) -> io::Result<()> {
-        self.close_path_edit();
-
         if self.directory_offset + 1 >= self.directory_stack.len() {
             // There is no previous directory that can be loaded
             return Ok(());
@@ -2226,8 +2222,6 @@ impl FileDialog {
     /// If the directory doesn't have a parent, Ok() is returned and nothing changes.
     /// Otherwise, the result of the directory loading operation is returned.
     fn load_parent_directory(&mut self) -> io::Result<()> {
-        self.close_path_edit();
-
         if let Some(x) = self.current_directory() {
             if let Some(x) = x.to_path_buf().parent() {
                 return self.load_directory(x);
@@ -2244,8 +2238,6 @@ impl FileDialog {
     /// In most cases, this function should not be called directly.
     /// Instead, `refresh` should be used to reload all other data like system disks too.
     fn reload_directory(&mut self) -> io::Result<()> {
-        self.close_path_edit();
-
         if let Some(x) = self.current_directory() {
             return self.load_directory_content(x.to_path_buf().as_path());
         }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2242,6 +2242,8 @@ impl FileDialog {
             match DirectoryContent::from_path(&self.config, path, self.show_files) {
                 Ok(content) => content,
                 Err(err) => {
+                    self.directory_content.clear();
+                    self.selected_item = None;
                     self.directory_error = Some(err.to_string());
                     return Err(err);
                 }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1767,7 +1767,7 @@ impl FileDialog {
         }
 
         if FileDialogKeyBindings::any_pressed(ctx, &keybindings.edit_path)
-            && self.config.show_new_folder_button
+            && self.config.show_path_edit_button
         {
             self.open_path_edit();
         }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -220,7 +220,7 @@ impl FileDialog {
             file_name_input: String::new(),
             file_name_input_error: None,
             file_name_input_request_focus: true,
-            
+
             scroll_to_selection: false,
             search_value: String::new(),
 
@@ -1726,9 +1726,9 @@ impl FileDialog {
     }
 
     /// Sets the cursor position to the end of a text input field.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `re` - response of the text input widget
     /// * `data` - buffer holding the text of the input widget
     fn set_cursor_to_end(re: &egui::Response, data: &str) {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -161,6 +161,8 @@ pub struct FileDialog {
     /// This variables contains the error message if the file_name_input is invalid.
     /// This can be the case, for example, if a file or folder with the name already exists.
     file_name_input_error: Option<String>,
+    /// If the file name input text field should request focus in the next frame.
+    file_name_input_request_focus: bool,
 
     /// If we should scroll to the item selected by the user in the next frame.
     scroll_to_selection: bool,
@@ -213,6 +215,7 @@ impl FileDialog {
             selected_item: None,
             file_name_input: String::new(),
             file_name_input_error: None,
+            file_name_input_request_focus: true,
 
             scroll_to_selection: false,
             search_value: String::new(),
@@ -1390,7 +1393,7 @@ impl FileDialog {
         visible
     }
 
-    /// Updates the list of devices like system disks
+    /// Updates the list of devices like system disks.
     ///
     /// Returns true if at least one device was included in the list and the
     /// heading is visible. If no device was listed, false is returned.
@@ -1500,8 +1503,17 @@ impl FileDialog {
                             .desired_width(f32::INFINITY),
                     );
 
+                    if self.file_name_input_request_focus {
+                        response.request_focus();
+                        self.file_name_input_request_focus = false;
+                    }
+
                     if response.changed() {
                         self.file_name_input_error = self.validate_file_name_input();
+                    }
+
+                    if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                        self.submit();
                     }
                 }
             };
@@ -1955,6 +1967,7 @@ impl FileDialog {
         self.selected_item = None;
         self.file_name_input = String::new();
         self.file_name_input_error = None;
+        self.file_name_input_request_focus = true;
 
         self.scroll_to_selection = false;
         self.search_value = String::new();

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1771,7 +1771,14 @@ impl FileDialog {
     fn exec_keybinding_submit(&mut self) {
         // The submit button (Enter) is used to open the directory that is currently selected
         if let Some(item) = &self.selected_item {
-            if item.is_dir() {
+            // Make sure the selected item is visible inside the directory view.
+            let is_visible = self
+                .directory_content
+                .filtered_iter(&self.search_value)
+                .position(|p| p == item)
+                .is_some();
+
+            if is_visible && item.is_dir() {
                 let _ = self.load_directory(&item.to_path_buf());
                 return;
             }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1942,37 +1942,10 @@ impl FileDialog {
     }
 
     /// Resets the dialog to use default values.
-    /// Configuration variables such as `initial_directory` are retained.
+    /// Configuration variables are retained.
     fn reset(&mut self) {
-        self.modals = Vec::new();
-
-        self.state = DialogState::Closed;
-        self.show_files = true;
-        self.operation_id = None;
-
-        self.user_directories = UserDirectories::new(self.config.canonicalize_paths);
-        self.system_disks = Disks::new_with_refreshed_list(self.config.canonicalize_paths);
-
-        self.directory_stack = Vec::new();
-        self.directory_offset = 0;
-        self.directory_content = DirectoryContent::new();
-        self.directory_error = None;
-
-        self.create_directory_dialog = CreateDirectoryDialog::new();
-
-        self.path_edit_visible = false;
-        self.path_edit_value = String::new();
-        self.path_edit_request_focus = false;
-
-        self.selected_item = None;
-        self.file_name_input = String::new();
-        self.file_name_input_error = None;
-        self.file_name_input_request_focus = true;
-
-        self.scroll_to_selection = false;
-        self.search_value = String::new();
-
-        self.any_focused_last_frame = false;
+        let config = self.config.clone();
+        *self = FileDialog::with_config(config);
     }
 
     /// Refreshes the dialog.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1627,6 +1627,7 @@ impl FileDialog {
 
                         if selected && self.scroll_to_selection {
                             response.scroll_to_me(Some(egui::Align::Center));
+                            self.scroll_to_selection = false;
                         }
 
                         if response.clicked() {
@@ -1645,7 +1646,6 @@ impl FileDialog {
                         }
                     }
 
-                    self.scroll_to_selection = false;
                     self.directory_content = data;
 
                     if let Some(path) = self
@@ -1864,8 +1864,6 @@ impl FileDialog {
             return;
         }
 
-        self.close_path_edit();
-
         if let Some(selection) = &self.selected_item {
             if let Some(index) = selection.index {
                 if index == 0 {
@@ -1889,8 +1887,6 @@ impl FileDialog {
         if self.directory_content.len() == 0 {
             return;
         }
-
-        self.close_path_edit();
 
         if let Some(selection) = &self.selected_item {
             if let Some(index) = selection.index {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1762,7 +1762,7 @@ impl FileDialog {
                 // We want to use the submit button (Enter) to enter a new directory instead of
                 // selecting the current one.
                 // We might want to change this behavior later.
-                DialogMode::SelectDirectory => {},
+                DialogMode::SelectDirectory => {}
             }
         }
     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1721,13 +1721,13 @@ impl FileDialog {
     fn update_keyboard_input(&mut self, ctx: &egui::Context) {
         let keybindings = std::mem::take(&mut self.config.keybindings);
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.open_previous_directory)
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.back)
             && self.config.show_back_button
         {
             let _ = self.load_previous_directory();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.open_next_directory)
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.forward)
             && self.config.show_forward_button
         {
             let _ = self.load_next_directory();

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -4,7 +4,8 @@ use std::{fs, io};
 use egui::text::{CCursor, CCursorRange};
 
 use crate::config::{
-    FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, Filter, QuickAccess,
+    FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, FileDialogStorage, Filter,
+    QuickAccess,
 };
 use crate::create_directory_dialog::CreateDirectoryDialog;
 use crate::data::{DirectoryContent, DirectoryEntry, Disk, Disks, UserDirectories};
@@ -37,23 +38,6 @@ pub enum DialogState {
 
     /// The user cancelled the dialog and didn't select anything.
     Cancelled,
-}
-
-/// Contains data of the FileDialog that should be stored persistently.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "persistence", derive(serde::Deserialize, serde::Serialize))]
-pub struct FileDialogStorage {
-    /// The folders the user pinned to the left sidebar.
-    pub pinned_folders: Vec<DirectoryEntry>,
-}
-
-impl Default for FileDialogStorage {
-    /// Creates a new object with default values
-    fn default() -> Self {
-        Self {
-            pinned_folders: Vec::new(),
-        }
-    }
 }
 
 /// Represents a file dialog instance.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1932,6 +1932,8 @@ impl FileDialog {
     /// Resets the dialog to use default values.
     /// Configuration variables such as `initial_directory` are retained.
     fn reset(&mut self) {
+        self.modals = Vec::new();
+
         self.state = DialogState::Closed;
         self.show_files = true;
         self.operation_id = None;
@@ -1939,18 +1941,25 @@ impl FileDialog {
         self.user_directories = UserDirectories::new(self.config.canonicalize_paths);
         self.system_disks = Disks::new_with_refreshed_list(self.config.canonicalize_paths);
 
-        self.directory_stack = vec![];
+        self.directory_stack = Vec::new();
         self.directory_offset = 0;
         self.directory_content = DirectoryContent::new();
         self.directory_error = None;
 
         self.create_directory_dialog = CreateDirectoryDialog::new();
 
+        self.path_edit_visible = false;
+        self.path_edit_value = String::new();
+        self.path_edit_request_focus = false;
+
         self.selected_item = None;
         self.file_name_input = String::new();
+        self.file_name_input_error = None;
 
         self.scroll_to_selection = false;
         self.search_value = String::new();
+
+        self.any_focused_last_frame = false;
     }
 
     /// Refreshes the dialog.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,5 +161,8 @@ mod data;
 mod file_dialog;
 mod modals;
 
-pub use config::{FileDialogConfig, FileDialogLabels};
+pub use config::{
+    FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, IconFilter, KeyBinding, QuickAccess,
+    QuickAccessPath,
+};
 pub use file_dialog::{DialogMode, DialogState, FileDialog, FileDialogStorage};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ mod file_dialog;
 mod modals;
 
 pub use config::{
-    FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, IconFilter, KeyBinding, QuickAccess,
-    QuickAccessPath,
+    FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, FileDialogStorage, IconFilter,
+    KeyBinding, QuickAccess, QuickAccessPath,
 };
-pub use file_dialog::{DialogMode, DialogState, FileDialog, FileDialogStorage};
+pub use file_dialog::{DialogMode, DialogState, FileDialog};

--- a/src/modals/mod.rs
+++ b/src/modals/mod.rs
@@ -6,6 +6,7 @@ mod overwrite_file_modal;
 pub use overwrite_file_modal::OverwriteFileModal;
 
 /// Contains actions that are executed by the file dialog when closing a modal.
+#[derive(Clone)]
 pub enum ModalAction {
     /// If no action should be executed.
     None,
@@ -14,6 +15,7 @@ pub enum ModalAction {
     SaveFile(PathBuf),
 }
 
+#[derive(Clone)]
 pub enum ModalState {
     /// If the modal is currently open and still waiting for user input
     Pending,

--- a/src/modals/mod.rs
+++ b/src/modals/mod.rs
@@ -25,4 +25,7 @@ pub trait FileDialogModal {
     /// Main update method of the modal.
     /// Should be called every time the modal should be visible.
     fn update(&mut self, config: &FileDialogConfig, ui: &mut egui::Ui) -> ModalState;
+
+    /// Updates the configured keybindings for the modal window.
+    fn update_keybindings(&mut self, _config: &FileDialogConfig, _ctx: &egui::Context) {}
 }

--- a/src/modals/overwrite_file_modal.rs
+++ b/src/modals/overwrite_file_modal.rs
@@ -1,11 +1,13 @@
 use std::path::PathBuf;
 
 use super::{FileDialogModal, ModalAction, ModalState};
-use crate::config::FileDialogConfig;
+use crate::config::{FileDialogConfig, FileDialogKeyBindings};
 
 /// The modal that is used to ask the user if the selected path should be
 /// overwritten.
 pub struct OverwriteFileModal {
+    /// The current state of the modal.
+    state: ModalState,
     /// The path selected for overwriting.
     path: PathBuf,
 }
@@ -17,14 +19,27 @@ impl OverwriteFileModal {
     ///
     /// * `path` - The path selected for overwriting.
     pub fn new(path: PathBuf) -> Self {
-        Self { path }
+        Self {
+            state: ModalState::Pending,
+            path
+        }
+    }
+}
+
+impl OverwriteFileModal {
+    /// Submits the modal and triggers the action to save the file.
+    fn submit(&mut self) {
+        self.state = ModalState::Close(ModalAction::SaveFile(self.path.to_path_buf()));
+    }
+
+    /// Closes the modal without overwriting the file.
+    fn cancel(&mut self) {
+        self.state = ModalState::Close(ModalAction::None);
     }
 }
 
 impl FileDialogModal for OverwriteFileModal {
     fn update(&mut self, config: &FileDialogConfig, ui: &mut egui::Ui) -> ModalState {
-        let mut return_val = ModalState::Pending;
-
         const SECTION_SPACING: f32 = 15.0;
         const BUTTON_SIZE: egui::Vec2 = egui::Vec2::new(90.0, 20.0);
 
@@ -65,7 +80,7 @@ impl FileDialogModal for OverwriteFileModal {
                     .add_sized(BUTTON_SIZE, egui::Button::new(&config.labels.cancel))
                     .clicked()
                 {
-                    return_val = ModalState::Close(ModalAction::None);
+                    self.cancel()
                 }
 
                 ui.add_space(ui.style().spacing.item_spacing.x);
@@ -74,11 +89,21 @@ impl FileDialogModal for OverwriteFileModal {
                     .add_sized(BUTTON_SIZE, egui::Button::new(&config.labels.overwrite))
                     .clicked()
                 {
-                    return_val = ModalState::Close(ModalAction::SaveFile(self.path.to_path_buf()));
+                    self.submit();
                 }
             });
         });
 
-        return_val
+        self.state.clone()
+    }
+
+    fn update_keybindings(&mut self, config: &FileDialogConfig, ctx: &egui::Context) {
+        if FileDialogKeyBindings::any_pressed(ctx, &config.keybindings.submit) {
+            self.submit();
+        }
+
+        if FileDialogKeyBindings::any_pressed(ctx, &config.keybindings.cancel) {
+            self.cancel();
+        }
     }
 }

--- a/src/modals/overwrite_file_modal.rs
+++ b/src/modals/overwrite_file_modal.rs
@@ -21,7 +21,7 @@ impl OverwriteFileModal {
     pub fn new(path: PathBuf) -> Self {
         Self {
             state: ModalState::Pending,
-            path
+            path,
         }
     }
 }


### PR DESCRIPTION
Implemented first version of configurable keyboard navigation. \
The following keybindings and their default values have been implemented:

- [x] submit - `Key::Enter`
- [x] cancel - `Key::Escape`
- [x] parent - `Modifiers::ALT, Key::ArrowUp`
- [x] back - `PointerButton::Extra1` , `Modifiers::ALT, Key::ArrowLeft`, `Key::Backspace`
- [x] forward - `PointerButton::Extra2` , `Modifiers::ALT, Key::ArrowRight`
- [x] reload - `Key::F5`
- [x] new_folder - `Modifiers::CTRL, Key::N`
- [x] edit_path - `Key::Slash`, `Key::Backslash`
- [x] selection_up - `Key::ArrowUp`
- [x] selection_down - `Key::ArrowDown`

Further todos:
- [x] Fix selection when a search value is entered
- [x] Don't register (text) keyboard input when any text input is currently active
- [x] Fix pressing escape inside the file name input closes the file dialog
- [x] Try finishing the dialog when pressing enter inside the file name input
- [x] Update changelog

Closes https://github.com/fluxxcode/egui-file-dialog/issues/70