### PR TITLE
Hidden files and folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## Unreleased - v0.6.0
 ### ✨ Features
 - Added the ability to pin folders to the left sidebar and enable or disable the feature with `FileDialog::show_pinned_folders` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100)
-- Added `FileDialogConfig::storage`, `FileDialog::storage` and `FileDialog::storage_mut` to be able to save and load the pinned folders [#104](https://github.com/fluxxcode/egui-file-dialog/pull/104) and [#105](https://github.com/fluxxcode/egui-file-dialog/pull/105)
+- Added `FileDialogConfig::storage`, `FileDialog::storage` and `FileDialog::storage_mut` to be able to save and load persistent data [#104](https://github.com/fluxxcode/egui-file-dialog/pull/104) and [#105](https://github.com/fluxxcode/egui-file-dialog/pull/105)
 - Added new modal and option `FileDialog::allow_file_overwrite` to allow overwriting an already existing file when the dialog is in `DialogMode::SaveFile` mode [#106](https://github.com/fluxxcode/egui-file-dialog/pull/106)
 - Implemented customizable keyboard navigation using `FileDialogKeybindings` and `FileDialog::keybindings` [#110](https://github.com/fluxxcode/egui-file-dialog/pull/110)
+- Implemented show hidden files and folders option [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111)
 
 ### ☢️ Deprecated
 - Deprecated `FileDialog::overwrite_config`. Use `FileDialog::with_config` and `FileDialog::config_mut` instead [#103](https://github.com/fluxxcode/egui-file-dialog/pull/103)
@@ -15,6 +16,7 @@
 
 ### 🔧 Changes
 - Restructured `config` module and fixed new `1.78` clippy warnings [#109](https://github.com/fluxxcode/egui-file-dialog/pull/109)
+- The reload button has been changed to a menu button. This menu contains the reload button and the “Show hidden option [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111)
 
 ### 📚 Documentation
 - Added `persistence` example showing how to save the persistent data of the file dialog [#107](https://github.com/fluxxcode/egui-file-dialog/pull/107)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 🔧 Changes
 - Restructured `config` module and fixed new `1.78` clippy warnings [#109](https://github.com/fluxxcode/egui-file-dialog/pull/109)
-- The reload button has been changed to a menu button. This menu contains the reload button and the “Show hidden option [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111)
+- The reload button has been changed to a menu button. This menu contains the reload button and the “Show hidden" option [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111)
 
 ### 📚 Documentation
 - Added `persistence` example showing how to save the persistent data of the file dialog [#107](https://github.com/fluxxcode/egui-file-dialog/pull/107)

--- a/examples/multilingual/src/main.rs
+++ b/examples/multilingual/src/main.rs
@@ -18,6 +18,9 @@ fn get_labels_german() -> FileDialogLabels {
         cancel: "Abbrechen".to_string(),
         overwrite: "Überschreiben".to_string(),
 
+        reload: "⟲  Neu laden".to_string(),
+        show_hidden: " Versteckte Dateien anzeigen".to_string(),
+
         heading_pinned: "Angeheftet".to_string(),
         heading_places: "Orte".to_string(),
         heading_devices: "Medien".to_string(),

--- a/src/config/labels.rs
+++ b/src/config/labels.rs
@@ -36,6 +36,13 @@ pub struct FileDialogLabels {
     pub overwrite: String,
 
     // ------------------------------------------------------------------------
+    // Top panel:
+    /// Text used for the option to reload the file dialog.
+    pub reload: String,
+    /// Text used for the option to show or hide hidden files and folders.
+    pub show_hidden: String,
+
+    // ------------------------------------------------------------------------
     // Left panel:
     /// Heading of the "Pinned" sections in the left panel
     pub heading_pinned: String,
@@ -111,6 +118,9 @@ impl Default for FileDialogLabels {
 
             cancel: "Cancel".to_string(),
             overwrite: "Overwrite".to_string(),
+
+            reload: "⟲  Reload".to_string(),
+            show_hidden: " Show hidden".to_string(),
 
             heading_pinned: "Pinned".to_string(),
             heading_places: "Places".to_string(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,6 +16,8 @@ use crate::data::DirectoryEntry;
 pub struct FileDialogStorage {
     /// The folders the user pinned to the left sidebar.
     pub pinned_folders: Vec<DirectoryEntry>,
+    /// If hidden files and folders should be listed inside the directory view.
+    pub show_hidden: bool,
 }
 
 impl Default for FileDialogStorage {
@@ -23,6 +25,7 @@ impl Default for FileDialogStorage {
     fn default() -> Self {
         Self {
             pinned_folders: Vec::new(),
+            show_hidden: false,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -151,8 +151,12 @@ pub struct FileDialogConfig {
     pub show_current_path: bool,
     /// If the button to text edit the current path should be visible.
     pub show_path_edit_button: bool,
-    /// If the reload button in the top panel should be visible.
+    /// If the menu button containing the reload button and other options should be visible.
+    pub show_menu_button: bool,
+    /// If the reload button inside the top panel menu should be visible.
     pub show_reload_button: bool,
+    /// If the show hidden files and folders option inside the top panel menu should be visible.
+    pub show_hidden_option: bool,
     /// If the search input in the top panel should be visible.
     pub show_search: bool,
 
@@ -215,7 +219,9 @@ impl Default for FileDialogConfig {
             show_new_folder_button: true,
             show_current_path: true,
             show_path_edit_button: true,
+            show_menu_button: true,
             show_reload_button: true,
+            show_hidden_option: true,
             show_search: true,
 
             show_left_panel: true,

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -213,7 +213,7 @@ fn is_path_hidden(item: &DirectoryEntry) -> bool {
 
     match fs::metadata(item.as_path()) {
         Ok(metadata) => metadata.file_attributes() & 0x2 > 0,
-        Err(_) => false
+        Err(_) => false,
     }
 }
 

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -209,9 +209,12 @@ fn load_directory(
 
 #[cfg(windows)]
 fn is_path_hidden(item: &DirectoryEntry) -> bool {
-    // TODO: Implement show hidden files/folders option on Windows.
-    // https://users.rust-lang.org/t/read-windows-hidden-file-attribute/51180
-    false
+    use std::os::windows::fs::MetadataExt;
+
+    match fs::metadata(item.as_path()) {
+        Ok(metadata) => metadata.file_attributes() & 0x2 > 0,
+        Err(_) => false
+    }
 }
 
 #[cfg(not(windows))]

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -94,6 +94,10 @@ impl DirectoryEntry {
                 ""
             })
     }
+
+    pub fn is_hidden(&self) -> bool {
+        is_path_hidden(&self)
+    }
 }
 
 /// Contains the content of a directory.
@@ -121,7 +125,7 @@ impl DirectoryContent {
     }
 
     /// Checks if the given directory entry is visible with the applied filters.
-    fn is_entry_visible(dir_entry: &DirectoryEntry, search_value: &str) -> bool {
+    fn is_entry_visible(dir_entry: &DirectoryEntry, show_hidden: bool, search_value: &str) -> bool {
         if !search_value.is_empty()
             && !dir_entry
                 .file_name()
@@ -131,16 +135,21 @@ impl DirectoryContent {
             return false;
         }
 
+        if !show_hidden && dir_entry.is_hidden() {
+            return false;
+        }
+
         true
     }
 
     pub fn filtered_iter<'s>(
         &'s self,
+        show_hidden: bool,
         search_value: &'s str,
     ) -> impl Iterator<Item = &DirectoryEntry> + 's {
         self.content
             .iter()
-            .filter(|p| Self::is_entry_visible(p, search_value))
+            .filter(move |p| Self::is_entry_visible(p, show_hidden, search_value))
     }
 
     /// Returns the number of elements inside the directory.
@@ -195,9 +204,23 @@ fn load_directory(
         },
     });
 
-    // TODO: Implement "Show hidden files and folders" option
-
     Ok(result)
+}
+
+#[cfg(windows)]
+fn is_path_hidden(item: &DirectoryEntry) -> bool {
+    // TODO: Implement show hidden files/folders option on Windows.
+    // https://users.rust-lang.org/t/read-windows-hidden-file-attribute/51180
+    false
+}
+
+#[cfg(not(windows))]
+fn is_path_hidden(item: &DirectoryEntry) -> bool {
+    if item.file_name().bytes().next() == Some(b'.') {
+        return true;
+    }
+
+    false
 }
 
 /// Generates the icon for the specific path.

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -96,7 +96,7 @@ impl DirectoryEntry {
     }
 
     pub fn is_hidden(&self) -> bool {
-        is_path_hidden(&self)
+        is_path_hidden(self)
     }
 }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -701,11 +701,31 @@ impl FileDialog {
         self
     }
 
-    /// Sets whether the reload button should be visible in the top panel.
+    /// Sets whether the menu with the reload button and other options should be visible
+    /// inside the top panel.
     ///
     /// Has no effect when `FileDialog::show_top_panel` is disabled.
+    pub fn show_menu_button(mut self, show_menu_button: bool) -> Self {
+        self.config.show_menu_button = show_menu_button;
+        self
+    }
+
+    /// Sets whether the reload button inside the top panel menu should be visible.
+    ///
+    /// Has no effect when `FileDialog::show_top_panel` or
+    /// `FileDialog::show_menu_button` is disabled.
     pub fn show_reload_button(mut self, show_reload_button: bool) -> Self {
         self.config.show_reload_button = show_reload_button;
+        self
+    }
+
+    /// Sets whether the show hidden files and folders option inside the top panel
+    /// menu should be visible.
+    ///
+    /// Has no effect when `FileDialog::show_top_panel` or
+    /// `FileDialog::show_menu_button` is disabled.
+    pub fn show_hidden_option(mut self, show_hidden_option: bool) -> Self {
+        self.config.show_hidden_option = show_hidden_option;
         self
     }
 
@@ -949,30 +969,35 @@ impl FileDialog {
             }
 
             // Menu button containing reload button and different options
-            ui.allocate_ui_with_layout(
-                BUTTON_SIZE,
-                egui::Layout::centered_and_justified(egui::Direction::LeftToRight),
-                |ui| {
-                    ui.menu_button("☰", |ui| {
-                        if self.config.show_reload_button
-                            && ui.button(&self.config.labels.reload).clicked()
-                        {
-                            self.refresh();
-                            ui.close_menu();
-                        }
+            if self.config.show_menu_button
+                && (self.config.show_reload_button || self.config.show_hidden_option)
+            {
+                ui.allocate_ui_with_layout(
+                    BUTTON_SIZE,
+                    egui::Layout::centered_and_justified(egui::Direction::LeftToRight),
+                    |ui| {
+                        ui.menu_button("☰", |ui| {
+                            if self.config.show_reload_button
+                                && ui.button(&self.config.labels.reload).clicked()
+                            {
+                                self.refresh();
+                                ui.close_menu();
+                            }
 
-                        if ui
-                            .checkbox(
-                                &mut self.config.storage.show_hidden,
-                                &self.config.labels.show_hidden,
-                            )
-                            .clicked()
-                        {
-                            ui.close_menu();
-                        }
-                    });
-                },
-            );
+                            if self.config.show_hidden_option
+                                && ui
+                                    .checkbox(
+                                        &mut self.config.storage.show_hidden,
+                                        &self.config.labels.show_hidden,
+                                    )
+                                    .clicked()
+                            {
+                                ui.close_menu();
+                            }
+                        });
+                    },
+                );
+            }
 
             if self.config.show_search {
                 self.ui_update_search(ui);

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -80,8 +80,6 @@ pub struct FileDialog {
     /// If files are displayed in addition to directories.
     /// This option will be ignored when mode == DialogMode::SelectFile.
     show_files: bool,
-    /// If hidden files and directories should be visible inside the directory view.
-    show_hidden: bool,
     /// This is an optional ID that can be set when opening the dialog to determine which
     /// operation the dialog is used for. This is useful if the dialog is used multiple times
     /// for different actions in the same view. The ID then makes it possible to distinguish
@@ -166,7 +164,6 @@ impl FileDialog {
             mode: DialogMode::SelectDirectory,
             state: DialogState::Closed,
             show_files: true,
-            show_hidden: false,
             operation_id: None,
 
             user_directories: UserDirectories::new(true),
@@ -965,7 +962,10 @@ impl FileDialog {
                         }
 
                         if ui
-                            .checkbox(&mut self.show_hidden, &self.config.labels.show_hidden)
+                            .checkbox(
+                                &mut self.config.storage.show_hidden,
+                                &self.config.labels.show_hidden,
+                            )
                             .clicked()
                         {
                             ui.close_menu();
@@ -1575,7 +1575,9 @@ impl FileDialog {
                     // of the function.
                     let data = std::mem::take(&mut self.directory_content);
 
-                    for path in data.filtered_iter(self.show_hidden, &self.search_value.clone()) {
+                    for path in data
+                        .filtered_iter(self.config.storage.show_hidden, &self.search_value.clone())
+                    {
                         let file_name = path.file_name();
 
                         let mut selected = false;
@@ -1781,7 +1783,7 @@ impl FileDialog {
             // Make sure the selected item is visible inside the directory view.
             let is_visible = self
                 .directory_content
-                .filtered_iter(self.show_hidden, &self.search_value)
+                .filtered_iter(self.config.storage.show_hidden, &self.search_value)
                 .any(|p| p == item);
 
             if is_visible && item.is_dir() {
@@ -2071,12 +2073,12 @@ impl FileDialog {
         let search_value = self.search_value.clone();
 
         if let Some(index) = directory_content
-            .filtered_iter(self.show_hidden, &search_value)
+            .filtered_iter(self.config.storage.show_hidden, &search_value)
             .position(|p| p == item)
         {
             if index != 0 {
                 if let Some(item) = directory_content
-                    .filtered_iter(self.show_hidden, &search_value)
+                    .filtered_iter(self.config.storage.show_hidden, &search_value)
                     .nth(index.saturating_sub(1))
                 {
                     self.select_item(item.clone());
@@ -2102,11 +2104,11 @@ impl FileDialog {
         let search_value = self.search_value.clone();
 
         if let Some(index) = directory_content
-            .filtered_iter(self.show_hidden, &search_value)
+            .filtered_iter(self.config.storage.show_hidden, &search_value)
             .position(|p| p == item)
         {
             if let Some(item) = directory_content
-                .filtered_iter(self.show_hidden, &search_value)
+                .filtered_iter(self.config.storage.show_hidden, &search_value)
                 .nth(index.saturating_add(1))
             {
                 self.select_item(item.clone());
@@ -2125,7 +2127,7 @@ impl FileDialog {
         let directory_content = std::mem::take(&mut self.directory_content);
 
         if let Some(item) = directory_content
-            .filtered_iter(self.show_hidden, &self.search_value.clone())
+            .filtered_iter(self.config.storage.show_hidden, &self.search_value.clone())
             .next()
         {
             self.select_item(item.clone());
@@ -2139,7 +2141,7 @@ impl FileDialog {
     fn select_last_visible_item(&mut self) {
         if let Some(item) = self
             .directory_content
-            .filtered_iter(self.show_hidden, &self.search_value)
+            .filtered_iter(self.config.storage.show_hidden, &self.search_value)
             .last()
         {
             self.select_item(item.clone());

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -938,7 +938,7 @@ impl FileDialog {
 
             let mut path_display_width = ui.available_width();
 
-            // Leave some area for the reload button and search input
+            // Leave some area for the menu button and search input
             if self.config.show_reload_button {
                 path_display_width -= BUTTON_SIZE.x + ui.style().spacing.item_spacing.x * 2.5;
             }
@@ -951,27 +951,23 @@ impl FileDialog {
                 self.ui_update_current_path(ui, path_display_width);
             }
 
-            let menu_button_response = ui.add_sized(BUTTON_SIZE, egui::Button::new("☰"));
+            // Menu button containing reload button and different options
+            ui.allocate_ui_with_layout(
+                BUTTON_SIZE,
+                egui::Layout::centered_and_justified(egui::Direction::LeftToRight),
+                |ui| {
+                    ui.menu_button("☰", |ui| {
+                        if self.config.show_reload_button && ui.button("⟲  Reload").clicked() {
+                            self.refresh();
+                            ui.close_menu();
+                        }
 
-            ui.menu_button(title, add_contents)
-
-            menu_button_response.context_menu(|ui| {
-                if self.config.show_reload_button && ui.button("⟲  Reload").clicked() {
-                    self.refresh();
-                    ui.close_menu();
-                }
-
-                if ui.checkbox(&mut self.show_hidden, " Show hidden").clicked() {
-                    ui.close_menu();
-                }
-            });
-
-            // Reload button
-            // if self.config.show_reload_button
-            //     && ui.add_sized(BUTTON_SIZE, egui::Button::new("⟲")).clicked()
-            // {
-            //     self.refresh();
-            // }
+                        if ui.checkbox(&mut self.show_hidden, " Show hidden").clicked() {
+                            ui.close_menu();
+                        }
+                    });
+                },
+            );
 
             if self.config.show_search {
                 self.ui_update_search(ui);
@@ -1714,31 +1710,6 @@ impl FileDialog {
                 .set_char_range(Some(CCursorRange::one(CCursor::new(data.len()))));
             state.store(&re.ctx, re.id);
         }
-    }
-
-    fn sized_menu_button<'c, R>(
-        ui: &mut egui::Ui,
-        title: impl Into<egui::WidgetText>,
-        add_contents: Box<dyn FnOnce(&mut egui::Ui) -> R + 'c>,
-    ) -> egui::InnerResponse<Option<R>> {
-        let title = title.into();
-        let bar_id = ui.id();
-        let menu_id = bar_id.with(title.text());
-    
-        let mut bar_state = egui::BarState::load(ui.ctx(), bar_id);
-    
-        let mut button = egui::Button::new(title);
-    
-        if bar_state.open_menu.is_menu_open(menu_id) {
-            button = button.fill(ui.visuals().widgets.open.weak_bg_fill);
-            button = button.stroke(ui.visuals().widgets.open.bg_stroke);
-        }
-    
-        let button_response = ui.add(button);
-        let inner = bar_state.bar_menu(&button_response, add_contents);
-    
-        bar_state.store(ui.ctx(), bar_id);
-        egui::InnerResponse::new(inner.map(|r| r.inner), button_response)
     }
 }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -957,12 +957,17 @@ impl FileDialog {
                 egui::Layout::centered_and_justified(egui::Direction::LeftToRight),
                 |ui| {
                     ui.menu_button("☰", |ui| {
-                        if self.config.show_reload_button && ui.button("⟲  Reload").clicked() {
+                        if self.config.show_reload_button
+                            && ui.button(&self.config.labels.reload).clicked()
+                        {
                             self.refresh();
                             ui.close_menu();
                         }
 
-                        if ui.checkbox(&mut self.show_hidden, " Show hidden").clicked() {
+                        if ui
+                            .checkbox(&mut self.show_hidden, &self.config.labels.show_hidden)
+                            .clicked()
+                        {
                             ui.close_menu();
                         }
                     });


### PR DESCRIPTION
This PR implements the feature to show or hide hidden files and folders.
For this purpose, the reload button was replaced with a menu button. In the menu you can now find the reload button and the show hidden option.

![Screenshot_20240526_165354](https://github.com/fluxxcode/egui-file-dialog/assets/55352293/2113e445-37cf-43ec-a234-06cfa4a539e9)

Changes:
- Added `FileDialog::show_menu_button`
- Added `FileDialog::show_hidden_option`
- Added `show_hidden` to `FileDialogStorage`
- Added `reload` and `show_hidden` to `FileDialogLabels`