### PR TITLE
Implement keep focus option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added new modal and option `FileDialog::allow_file_overwrite` to allow overwriting an already existing file when the dialog is in `DialogMode::SaveFile` mode [#106](https://github.com/fluxxcode/egui-file-dialog/pull/106)
 - Implemented customizable keyboard navigation using `FileDialogKeybindings` and `FileDialog::keybindings` [#110](https://github.com/fluxxcode/egui-file-dialog/pull/110)
 - Implemented show hidden files and folders option [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111)
+- Implemented `FileDialog::keep_focus` which keeps the file dialog in focus so it appears on top of all other windows, even if the user clicks outside the window [#112](https://github.com/fluxxcode/egui-file-dialog/pull/112)
 
 ### ☢️ Deprecated
 - Deprecated `FileDialog::overwrite_config`. Use `FileDialog::with_config` and `FileDialog::config_mut` instead [#103](https://github.com/fluxxcode/egui-file-dialog/pull/103)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -65,13 +65,16 @@ pub struct FileDialogConfig {
     // Core:
     /// Persistent data of the file dialog.
     pub storage: FileDialogStorage,
+    /// The labels that the dialog uses.
+    pub labels: FileDialogLabels,
     /// Keybindings used by the file dialog.
     pub keybindings: FileDialogKeyBindings,
 
     // ------------------------------------------------------------------------
     // General options:
-    /// The labels that the dialog uses.
-    pub labels: FileDialogLabels,
+    /// If the file dialog window should keep focus and appear on top of all other windows,
+    /// even if the user clicks outside the window.
+    pub keep_focus: bool,
     /// The first directory that will be opened when the dialog opens.
     pub initial_directory: PathBuf,
     /// The default filename when opening the dialog in `DialogMode::SaveFile` mode.
@@ -179,9 +182,10 @@ impl Default for FileDialogConfig {
     fn default() -> Self {
         Self {
             storage: FileDialogStorage::default(),
+            labels: FileDialogLabels::default(),
             keybindings: FileDialogKeyBindings::default(),
 
-            labels: FileDialogLabels::default(),
+            keep_focus: true,
             initial_directory: std::env::current_dir().unwrap_or_default(),
             default_file_name: String::new(),
             allow_file_overwrite: true,

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -437,6 +437,15 @@ impl FileDialog {
         &mut self.config.labels
     }
 
+    /// If the file dialog window should keep focus and appear on top of all other windows,
+    /// even if the user clicks outside the window.
+    /// However, this does not prevent the user from using other widgets outside of the
+    /// file dialog.
+    pub fn keep_focus(mut self, keep_focus: bool) -> Self {
+        self.config.keep_focus = keep_focus;
+        self
+    }
+
     /// Sets the first loaded directory when the dialog opens.
     /// If the path is a file, the file's parent directory is used. If the path then has no
     /// parent directory or cannot be loaded, the user will receive an error.
@@ -834,6 +843,10 @@ impl FileDialog {
         let mut is_open = true;
 
         self.create_window(&mut is_open).show(ctx, |ui| {
+            if self.config.keep_focus {
+                ui.ctx().move_to_top(ui.layer_id());
+            }
+
             if !self.modals.is_empty() {
                 self.ui_update_modals(ui);
                 return;


### PR DESCRIPTION
Implemented `FileDialog::keep_focus` option, which keeps the file dialog window in focus so that it appears on top of all other windows, even if the user clicks outside the window.
