### PR TITLE
Improve navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### 🔧 Changes
 - Restructured `config` module and fixed new `1.78` clippy warnings [#109](https://github.com/fluxxcode/egui-file-dialog/pull/109)
 - The reload button has been changed to a menu button. This menu contains the reload button and the “Show hidden" option [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111)
+- Minor navigation improvements [#113](https://github.com/fluxxcode/egui-file-dialog/pull/113)
 
 ### 📚 Documentation
 - Added `persistence` example showing how to save the persistent data of the file dialog [#107](https://github.com/fluxxcode/egui-file-dialog/pull/107)

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -29,10 +29,19 @@ impl KeyBinding {
     }
 
     /// Checks if the keybinding was pressed by the user.
-    pub fn pressed(&self, ctx: &egui::Context) -> bool {
+    ///
+    /// # Arguments
+    ///
+    /// * `ignore_if_any_focused` - Determines whether keyboard shortcuts pressed while another
+    ///    widget is currently in focus should be ignored.
+    ///    In most cases, this should be enabled so that no shortcuts are executed if,
+    ///    for example, the search  text field is currently in focus. With the selection
+    ///    keybindings, however, it is desired that when they are pressed, the text fields
+    ///    lose focus and the keybinding is executed.
+    pub fn pressed(&self, ctx: &egui::Context, ignore_if_any_focused: bool) -> bool {
         // We want to suppress keyboard input when any other widget like
         // text fields have focus.
-        if ctx.memory(|r| r.focused()).is_some() {
+        if ignore_if_any_focused && ctx.memory(|r| r.focused()).is_some() {
             return false;
         }
 
@@ -71,9 +80,13 @@ pub struct FileDialogKeyBindings {
 
 impl FileDialogKeyBindings {
     /// Checks wether any of the given keybindings is pressed.
-    pub fn any_pressed(ctx: &egui::Context, keybindings: &Vec<KeyBinding>) -> bool {
+    pub fn any_pressed(
+        ctx: &egui::Context,
+        keybindings: &Vec<KeyBinding>,
+        suppress_if_any_focused: bool,
+    ) -> bool {
         for keybinding in keybindings {
-            if keybinding.pressed(ctx) {
+            if keybinding.pressed(ctx, suppress_if_any_focused) {
                 return true;
             }
         }

--- a/src/create_directory_dialog.rs
+++ b/src/create_directory_dialog.rs
@@ -77,6 +77,18 @@ impl CreateDirectoryDialog {
         self.reset();
     }
 
+    /// Tries to create the given folder.
+    pub fn submit(&mut self) -> CreateDirectoryResponse {
+        // Only necessary in the event of an error
+        self.request_focus = true;
+
+        if self.error.is_none() {
+            return self.create_directory();
+        }
+
+        CreateDirectoryResponse::new_empty()
+    }
+
     /// Main update function of the dialog. Should be called in every frame
     /// in which the dialog is to be displayed.
     pub fn update(
@@ -117,23 +129,12 @@ impl CreateDirectoryDialog {
                 ui.add_enabled(self.error.is_none(), egui::Button::new("✔"));
 
             if apply_button_response.clicked() {
-                result = self.create_directory();
+                result = self.submit();
             }
 
-            if ui.button("✖").clicked() {
-                self.close();
-            }
-
-            if text_edit_response.lost_focus()
-                && ui.ctx().input(|input| input.key_pressed(egui::Key::Enter))
+            if ui.button("✖").clicked()
+                || (text_edit_response.lost_focus() && !apply_button_response.contains_pointer())
             {
-                // Only necessary in the event of an error
-                self.request_focus = true;
-
-                if self.error.is_none() {
-                    result = self.create_directory();
-                }
-            } else if text_edit_response.lost_focus() && !apply_button_response.contains_pointer() {
                 self.close();
             }
         });

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1839,13 +1839,18 @@ impl FileDialog {
     fn exec_keybinding_submit(&mut self) {
         if self.path_edit_visible {
             self.submit_path_edit();
-        } else if self.create_directory_dialog.is_open() {
+            return;
+        }
+
+        if self.create_directory_dialog.is_open() {
             if let Some(dir) = self.create_directory_dialog.submit().directory() {
                 self.process_new_folder(&dir);
             }
-        } else if let Some(item) = &self.selected_item {
-            // The submit button (Enter) is used to open the directory that is currently selected
+            return;
+        }
 
+        // Check if there is a directory selected we can open
+        if let Some(item) = &self.selected_item {
             // Make sure the selected item is visible inside the directory view.
             let is_visible = self
                 .directory_content
@@ -1858,13 +1863,7 @@ impl FileDialog {
             }
         }
 
-        match &self.mode {
-            DialogMode::SelectFile | DialogMode::SaveFile => self.submit(),
-            // We want to use the submit button (Enter) to enter a new directory instead of
-            // selecting the current one.
-            // We might want to change this behavior later.
-            DialogMode::SelectDirectory => {}
-        }
+        self.submit();
     }
 
     /// Executes the action when the keybinding `cancel` is pressed.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1806,6 +1806,7 @@ impl FileDialog {
         if FileDialogKeyBindings::any_pressed(ctx, &keybindings.selection_up, false) {
             self.exec_keybinding_selection_up();
 
+            // We want to break out of input fields like search when pressing selection keys
             if let Some(id) = ctx.memory(|r| r.focused()) {
                 ctx.memory_mut(|w| w.surrender_focus(id));
             }
@@ -1814,6 +1815,7 @@ impl FileDialog {
         if FileDialogKeyBindings::any_pressed(ctx, &keybindings.selection_down, false) {
             self.exec_keybinding_selection_down();
 
+            // We want to break out of input fields like search when pressing selection keys
             if let Some(id) = ctx.memory(|r| r.focused()) {
                 ctx.memory_mut(|w| w.surrender_focus(id));
             }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1193,11 +1193,11 @@ impl FileDialog {
         let btn_response = ui.add_sized(edit_button_size, egui::Button::new("✔"));
 
         if btn_response.clicked() {
-            self.submit_path_edit(true);
+            self.submit_path_edit();
         }
 
         if response.lost_focus() && ui.ctx().input(|input| input.key_pressed(egui::Key::Enter)) {
-            self.submit_path_edit(false);
+            self.submit_path_edit();
         } else if !response.has_focus() && !btn_response.contains_pointer() {
             self.path_edit_visible = false;
         }
@@ -2200,13 +2200,8 @@ impl FileDialog {
     }
 
     /// Loads the directory from the path text edit.
-    fn submit_path_edit(&mut self, close_text_edit: bool) {
-        if close_text_edit {
-            self.close_path_edit();
-        } else {
-            self.path_edit_request_focus = true;
-        }
-
+    fn submit_path_edit(&mut self) {
+        self.close_path_edit();
         let _ = self.load_directory(&self.canonicalize_path(&PathBuf::from(&self.path_edit_value)));
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1237,6 +1237,12 @@ impl FileDialog {
 
                         self.init_search = false;
                     }
+
+                    if re.lost_focus()
+                        && ui.ctx().input(|input| input.key_pressed(egui::Key::Enter))
+                    {
+                        self.submit();
+                    }
                 });
             });
     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1771,44 +1771,52 @@ impl FileDialog {
 
         let keybindings = std::mem::take(&mut self.config.keybindings);
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.submit) {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.submit, true) {
             self.exec_keybinding_submit();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.cancel) {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.cancel, true) {
             self.exec_keybinding_cancel();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.parent) {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.parent, true) {
             let _ = self.load_parent_directory();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.back) {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.back, true) {
             let _ = self.load_previous_directory();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.forward) {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.forward, true) {
             let _ = self.load_next_directory();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.reload) {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.reload, true) {
             self.refresh();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.new_folder) {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.new_folder, true) {
             self.open_new_folder_dialog();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.edit_path) {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.edit_path, true) {
             self.open_path_edit();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.selection_up) {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.selection_up, false) {
             self.exec_keybinding_selection_up();
+
+            if let Some(id) = ctx.memory(|r| r.focused()) {
+                ctx.memory_mut(|w| w.surrender_focus(id));
+            }
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.selection_down) {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.selection_down, false) {
             self.exec_keybinding_selection_down();
+
+            if let Some(id) = ctx.memory(|r| r.focused()) {
+                ctx.memory_mut(|w| w.surrender_focus(id));
+            }
         }
 
         self.config.keybindings = keybindings;

--- a/src/modals/overwrite_file_modal.rs
+++ b/src/modals/overwrite_file_modal.rs
@@ -98,11 +98,11 @@ impl FileDialogModal for OverwriteFileModal {
     }
 
     fn update_keybindings(&mut self, config: &FileDialogConfig, ctx: &egui::Context) {
-        if FileDialogKeyBindings::any_pressed(ctx, &config.keybindings.submit) {
+        if FileDialogKeyBindings::any_pressed(ctx, &config.keybindings.submit, true) {
             self.submit();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &config.keybindings.cancel) {
+        if FileDialogKeyBindings::any_pressed(ctx, &config.keybindings.cancel, true) {
             self.cancel();
         }
     }


### PR DESCRIPTION
Implemented the following navigation improvements:
- Selection keybindings now break out of text input fields
- Path editing is automatically closed when submitting
- When changing the search input, the first item is automatically selected
- When closing the search input with Enter, the file dialog attempts to submit the current selection
- Enter now selects the current directory if no other item is currently selected