### PR TITLE
Rename persistence feature to serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ sysinfo = { version = "0.30.5", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true}
 
 [features]
-default = ["persistence"]
-persistence = ["dep:serde"]
+default = ["serde"]
+serde = ["dep:serde"]

--- a/examples/persistence/README.md
+++ b/examples/persistence/README.md
@@ -1,5 +1,5 @@
 This example uses eframe to show how the persistent data of the file dialog can be saved. \
-If the default features of the file dialog are deactivated, the `persistence` feature must be enabled.
+The example uses the `serde` feature to serialize the required data.
 
 ```
 cargo run -p persistence

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,7 +12,7 @@ use crate::data::DirectoryEntry;
 
 /// Contains data of the FileDialog that should be stored persistently.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "persistence", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FileDialogStorage {
     /// The folders the user pinned to the left sidebar.
     pub pinned_folders: Vec<DirectoryEntry>,

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -7,7 +7,7 @@ use crate::FileDialogConfig;
 /// This struct is mainly there so that the metadata can be loaded once and not that
 /// a request has to be sent to the OS every frame using, for example, `path.is_file()`.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "persistence", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DirectoryEntry {
     path: PathBuf,
     is_directory: bool,


### PR DESCRIPTION
The `persistence` feature has been renamed to `serde` because it currently only implements `serde::Serialize` and `serde::Deserialize` for the persistent data.