### PR TITLE
Implement modal option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased - v0.6.0
 ### 🚨 Breaking Changes
 - Added new labels to `FileDialogLabels` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100), [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111)
-- Added new configuration values to `FileDialogConfig`  [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100), [#104](https://github.com/fluxxcode/egui-file-dialog/pull/104), [#106](https://github.com/fluxxcode/egui-file-dialog/pull/106), [#110](https://github.com/fluxxcode/egui-file-dialog/pull/110), [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111), [#112](https://github.com/fluxxcode/egui-file-dialog/pull/112)
+- Added new configuration values to `FileDialogConfig` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100), [#104](https://github.com/fluxxcode/egui-file-dialog/pull/104), [#106](https://github.com/fluxxcode/egui-file-dialog/pull/106), [#110](https://github.com/fluxxcode/egui-file-dialog/pull/110), [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111), [#112](https://github.com/fluxxcode/egui-file-dialog/pull/112), [#118](https://github.com/fluxxcode/egui-file-dialog/pull/118)
 
 ### ✨ Features
 - Added the ability to pin folders to the left sidebar and enable or disable the feature with `FileDialog::show_pinned_folders` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100)
@@ -12,6 +12,7 @@
 - Implemented customizable keyboard navigation using `FileDialogKeybindings` and `FileDialog::keybindings` [#110](https://github.com/fluxxcode/egui-file-dialog/pull/110)
 - Implemented show hidden files and folders option [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111)
 - Implemented `FileDialog::keep_focus` which keeps the file dialog in focus so it appears on top of all other windows, even if the user clicks outside the window [#112](https://github.com/fluxxcode/egui-file-dialog/pull/112)
+- The dialog is now displayed as a modal window by default. This can be disabled with `FileDialog::as_modal`. The color of the modal overlay can be adjusted using `FileDialog::modal_overlay_color`. [#118](https://github.com/fluxxcode/egui-file-dialog/pull/118)
 
 ### ☢️ Deprecated
 - Deprecated `FileDialog::overwrite_config`. Use `FileDialog::with_config` and `FileDialog::config_mut` instead [#103](https://github.com/fluxxcode/egui-file-dialog/pull/103)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -72,6 +72,11 @@ pub struct FileDialogConfig {
 
     // ------------------------------------------------------------------------
     // General options:
+    /// If the file dialog should be visible as a modal window.
+    /// This means that the input outside the window is not registered.
+    pub as_modal: bool,
+    /// Color of the overlay that is displayed under the modal to prevent user interaction.
+    pub modal_overlay_color: egui::Color32,
     /// If the file dialog window should keep focus and appear on top of all other windows,
     /// even if the user clicks outside the window.
     pub keep_focus: bool,
@@ -185,6 +190,8 @@ impl Default for FileDialogConfig {
             labels: FileDialogLabels::default(),
             keybindings: FileDialogKeyBindings::default(),
 
+            as_modal: true,
+            modal_overlay_color: egui::Color32::from_rgba_premultiplied(0, 0, 0, 120),
             keep_focus: true,
             initial_directory: std::env::current_dir().unwrap_or_default(),
             default_file_name: String::new(),


### PR DESCRIPTION
By default the file dialog is now displayed as modal. This will display an overlay under the window and disable interaction outside of the window. The modal can be deactivated with `FileDialog::as_modal` and the color of the modal overlay can be adjusted with `FileDialog::modal_overlay_color`.

![Screenshot_20240528_224259](https://github.com/fluxxcode/egui-file-dialog/assets/55352293/1fc479cb-38ab-4d41-a4c4-7c0b57183259)

Closes #117 