### PR TITLE
Make DirectoryEntry publicly reachable

### DIFF
--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -95,6 +95,7 @@ impl DirectoryEntry {
             })
     }
 
+    /// Returns whether the path this DirectoryEntry points to is considered hidden.
     pub fn is_hidden(&self) -> bool {
         is_path_hidden(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,4 +165,5 @@ pub use config::{
     FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, FileDialogStorage, IconFilter,
     KeyBinding, QuickAccess, QuickAccessPath,
 };
+pub use data::DirectoryEntry;
 pub use file_dialog::{DialogMode, DialogState, FileDialog};


### PR DESCRIPTION
It's already a public struct, but it's not reachable publicly, so it's not possible to for example construct an instance of it.

This commit makes it publically reachable by re-exporting it in the crate root, and also adds a missing doc string for `is_hidden`.