### PR TITLE
Implement file filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Implemented customizable keyboard navigation using `FileDialogKeybindings` and `FileDialog::keybindings` [#110](https://github.com/fluxxcode/egui-file-dialog/pull/110)
 - Implemented show hidden files and folders option [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111)
 - The dialog is now displayed as a modal window by default. This can be disabled with `FileDialog::as_modal`. The color of the modal overlay can be adjusted using `FileDialog::modal_overlay_color`. [#118](https://github.com/fluxxcode/egui-file-dialog/pull/118)
+- Added `FileDialog::add_file_filter` and `FileDialog::default_file_filter` to add file filters that can be selected by the user from a drop-down menu at the bottom [#124](https://github.com/fluxxcode/egui-file-dialog/pull/124)
 
 ### ☢️ Deprecated
 - Deprecated `FileDialog::overwrite_config`. Use `FileDialog::with_config` and `FileDialog::config_mut` instead [#103](https://github.com/fluxxcode/egui-file-dialog/pull/103)

--- a/examples/multilingual/src/main.rs
+++ b/examples/multilingual/src/main.rs
@@ -40,6 +40,7 @@ fn get_labels_german() -> FileDialogLabels {
         selected_directory: "Ausgewählter Ordner:".to_string(),
         selected_file: "Ausgewählte Datei:".to_string(),
         file_name: "Dateiname:".to_string(),
+        file_filter_all_files: "Alle Dateien".to_string(),
 
         open_button: "🗀  Öffnen".to_string(),
         save_button: "📥  Speichern".to_string(),

--- a/examples/sandbox/src/main.rs
+++ b/examples/sandbox/src/main.rs
@@ -19,9 +19,18 @@ impl MyApp {
                 s.add_path("📷  Media", "media");
                 s.add_path("📂  Source", "src");
             })
-            .add_file_filter("PNG files", Arc::new(|p| p.extension().unwrap_or_default() == "png"))
-            .add_file_filter("RS files", Arc::new(|p| p.extension().unwrap_or_default() == "rs"))
-            .add_file_filter("TOML files", Arc::new(|p| p.extension().unwrap_or_default() == "toml"))
+            .add_file_filter(
+                "PNG files",
+                Arc::new(|p| p.extension().unwrap_or_default() == "png"),
+            )
+            .add_file_filter(
+                "RS files",
+                Arc::new(|p| p.extension().unwrap_or_default() == "rs"),
+            )
+            .add_file_filter(
+                "TOML files",
+                Arc::new(|p| p.extension().unwrap_or_default() == "toml"),
+            )
             .id("egui_file_dialog");
 
         if let Some(storage) = cc.storage {

--- a/examples/sandbox/src/main.rs
+++ b/examples/sandbox/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use eframe::egui;
 use egui_file_dialog::{DialogMode, FileDialog};
@@ -19,6 +19,9 @@ impl MyApp {
                 s.add_path("📷  Media", "media");
                 s.add_path("📂  Source", "src");
             })
+            .add_file_filter("PNG files", Arc::new(|p| p.extension().unwrap_or_default() == "png"))
+            .add_file_filter("RS files", Arc::new(|p| p.extension().unwrap_or_default() == "rs"))
+            .add_file_filter("TOML files", Arc::new(|p| p.extension().unwrap_or_default() == "toml"))
             .id("egui_file_dialog");
 
         if let Some(storage) = cc.storage {

--- a/src/config/labels.rs
+++ b/src/config/labels.rs
@@ -83,6 +83,8 @@ pub struct FileDialogLabels {
     pub selected_file: String,
     /// Text that appears in front of the file name input in the bottom panel.
     pub file_name: String,
+    /// Text displayed in the file filter dropdown for the "All Files" option.
+    pub file_filter_all_files: String,
 
     /// Button text to open the selected item.
     pub open_button: String,
@@ -141,6 +143,7 @@ impl Default for FileDialogLabels {
             selected_directory: "Selected directory:".to_string(),
             selected_file: "Selected file:".to_string(),
             file_name: "File name:".to_string(),
+            file_filter_all_files: "All Files".to_string(),
 
             open_button: "🗀  Open".to_string(),
             save_button: "📥  Save".to_string(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -105,6 +105,8 @@ pub struct FileDialogConfig {
     /// The icon used to display removable devices in the left panel.
     pub removable_device_icon: String,
 
+    /// File filters presented to the user in a dropdown.
+    pub file_filters: Vec<FileFilter>,
     /// Sets custom icons for different files or folders.
     /// Use `FileDialogConfig::set_file_icon` to add a new icon to this list.
     pub file_icon_filters: Vec<IconFilter>,
@@ -203,6 +205,7 @@ impl Default for FileDialogConfig {
             device_icon: String::from("🖴"),
             removable_device_icon: String::from("💾"),
 
+            file_filters: Vec::new(),
             file_icon_filters: Vec::new(),
 
             quick_accesses: Vec::new(),
@@ -246,6 +249,37 @@ impl FileDialogConfig {
     /// file dialog instances.
     pub fn storage(mut self, storage: FileDialogStorage) -> Self {
         self.storage = storage;
+        self
+    }
+
+    /// Adds a new file filter the user can select from a dropdown widget.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Display name of the filter
+    /// * `filter` - Sets a filter function that checks whether a given
+    ///   Path matches the criteria for this filter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use egui_file_dialog::FileDialogConfig;
+    ///
+    /// let config = FileDialogConfig::default()
+    ///     .add_file_filter(
+    ///         "PNG files",
+    ///         Arc::new(|path| path.extension().unwrap_or_default() == "png"))
+    ///     .add_file_filter(
+    ///         "JPG files",
+    ///         Arc::new(|path| path.extension().unwrap_or_default() == "jpg"))
+    /// ```
+    pub fn add_file_filter(mut self, name: &str, filter: Filter<Path>) -> Self {
+        self.file_filters.push(FileFilter {
+            name: name.to_string(),
+            filter,
+        });
+
         self
     }
 
@@ -310,6 +344,23 @@ impl FileDialogConfig {
 
 /// Function that returns true if the specific item matches the filter.
 pub type Filter<T> = Arc<dyn Fn(&T) -> bool>;
+
+/// Defines a specific file filter that the user can select from a dropdown.
+#[derive(Clone)]
+pub struct FileFilter {
+    /// The display name of the file filter
+    pub name: String,
+    /// Sets a filter function that checks whether a given Path matches the criteria for this icon.
+    pub filter: Filter<Path>,
+}
+
+impl std::fmt::Debug for FileFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileFilter")
+            .field("name", &self.name)
+            .finish()
+    }
+}
 
 /// Sets a specific icon for directory entries.
 #[derive(Clone)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -366,7 +366,7 @@ pub struct FileFilter {
     pub id: egui::Id,
     /// The display name of the file filter
     pub name: String,
-    /// Sets a filter function that checks whether a given Path matches the criteria for this icon.
+    /// Sets a filter function that checks whether a given Path matches the criteria for this file.
     pub filter: Filter<Path>,
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -107,6 +107,8 @@ pub struct FileDialogConfig {
 
     /// File filters presented to the user in a dropdown.
     pub file_filters: Vec<FileFilter>,
+    /// Name of the file filter to be selected by default.
+    pub default_file_filter: Option<String>,
     /// Sets custom icons for different files or folders.
     /// Use `FileDialogConfig::set_file_icon` to add a new icon to this list.
     pub file_icon_filters: Vec<IconFilter>,
@@ -206,6 +208,7 @@ impl Default for FileDialogConfig {
             removable_device_icon: String::from("💾"),
 
             file_filters: Vec::new(),
+            default_file_filter: None,
             file_icon_filters: Vec::new(),
 
             quick_accesses: Vec::new(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -254,6 +254,9 @@ impl FileDialogConfig {
 
     /// Adds a new file filter the user can select from a dropdown widget.
     ///
+    /// NOTE: The name must be unique. If a filter with the same name already exists,
+    ///       it will be overwritten.
+    ///
     /// # Arguments
     ///
     /// * `name` - Display name of the filter
@@ -275,7 +278,15 @@ impl FileDialogConfig {
     ///         Arc::new(|path| path.extension().unwrap_or_default() == "jpg"))
     /// ```
     pub fn add_file_filter(mut self, name: &str, filter: Filter<Path>) -> Self {
+        let id = egui::Id::new(name);
+
+        if let Some(item) = self.file_filters.iter_mut().find(|p| p.id == id) {
+            item.filter = filter.clone();
+            return self;
+        }
+
         self.file_filters.push(FileFilter {
+            id,
             name: name.to_string(),
             filter,
         });
@@ -348,6 +359,8 @@ pub type Filter<T> = Arc<dyn Fn(&T) -> bool>;
 /// Defines a specific file filter that the user can select from a dropdown.
 #[derive(Clone)]
 pub struct FileFilter {
+    /// The ID of the file filter, used internally for identification.
+    pub id: egui::Id,
     /// The display name of the file filter
     pub name: String,
     /// Sets a filter function that checks whether a given Path matches the criteria for this icon.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -278,7 +278,7 @@ impl FileDialogConfig {
     ///         Arc::new(|path| path.extension().unwrap_or_default() == "png"))
     ///     .add_file_filter(
     ///         "JPG files",
-    ///         Arc::new(|path| path.extension().unwrap_or_default() == "jpg"))
+    ///         Arc::new(|path| path.extension().unwrap_or_default() == "jpg"));
     /// ```
     pub fn add_file_filter(mut self, name: &str, filter: Filter<Path>) -> Self {
         let id = egui::Id::new(name);

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-use crate::FileDialogConfig;
+use crate::config::{FileDialogConfig, FileFilter};
 
 /// Contains the metadata of a directory item.
 /// This struct is mainly there so that the metadata can be loaded once and not that
@@ -126,7 +126,12 @@ impl DirectoryContent {
     }
 
     /// Checks if the given directory entry is visible with the applied filters.
-    fn is_entry_visible(dir_entry: &DirectoryEntry, show_hidden: bool, search_value: &str) -> bool {
+    fn is_entry_visible(
+        dir_entry: &DirectoryEntry,
+        show_hidden: bool,
+        search_value: &str,
+        file_filter: Option<&FileFilter>,
+    ) -> bool {
         if !search_value.is_empty()
             && !dir_entry
                 .file_name()
@@ -140,6 +145,12 @@ impl DirectoryContent {
             return false;
         }
 
+        if let Some(file_filter) = file_filter {
+            if dir_entry.is_file() && !(file_filter.filter)(dir_entry.as_path()) {
+                return false;
+            }
+        }
+
         true
     }
 
@@ -147,10 +158,11 @@ impl DirectoryContent {
         &'s self,
         show_hidden: bool,
         search_value: &'s str,
+        file_filter: Option<&'s FileFilter>,
     ) -> impl Iterator<Item = &DirectoryEntry> + 's {
         self.content
             .iter()
-            .filter(move |p| Self::is_entry_visible(p, show_hidden, search_value))
+            .filter(move |p| Self::is_entry_visible(p, show_hidden, search_value, file_filter))
     }
 
     /// Returns the number of elements inside the directory.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -576,7 +576,7 @@ impl FileDialog {
     ///         Arc::new(|path| path.extension().unwrap_or_default() == "png"))
     ///     .add_file_filter(
     ///         "JPG files",
-    ///         Arc::new(|path| path.extension().unwrap_or_default() == "jpg"))
+    ///         Arc::new(|path| path.extension().unwrap_or_default() == "jpg"));
     /// ```
     pub fn add_file_filter(mut self, name: &str, filter: Filter<Path>) -> Self {
         self.config = self.config.add_file_filter(name, filter);

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -284,6 +284,14 @@ impl FileDialog {
                 .clone_from(&self.config.default_file_name);
         }
 
+        if let Some(name) = &self.config.default_file_filter {
+            for filter in &self.config.file_filters {
+                if &filter.name == name.as_str() {
+                    self.selected_file_filter = Some(filter.id);
+                }
+            }
+        }
+
         self.mode = mode;
         self.state = DialogState::Open;
         self.show_files = show_files;
@@ -572,6 +580,14 @@ impl FileDialog {
     /// ```
     pub fn add_file_filter(mut self, name: &str, filter: Filter<Path>) -> Self {
         self.config = self.config.add_file_filter(name, filter);
+        self
+    }
+
+    /// Name of the file filter to be selected by default.
+    ///
+    /// No file filter is selected if there is no file filter with that name.
+    pub fn default_file_filter(mut self, name: &str) -> Self {
+        self.config.default_file_filter = Some(name.to_string());
         self
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1665,7 +1665,7 @@ impl FileDialog {
         let selected_filter = self.get_selected_file_filter();
         let selected_text = match selected_filter {
             Some(f) => &f.name,
-            None => "All files",
+            None => &self.config.labels.file_filter_all_files,
         };
 
         // The item that the user selected inside the drop down.
@@ -1688,7 +1688,10 @@ impl FileDialog {
                 }
 
                 if ui
-                    .selectable_label(selected_filter.is_none(), "All files")
+                    .selectable_label(
+                        selected_filter.is_none(),
+                        &self.config.labels.file_filter_all_files,
+                    )
                     .clicked()
                 {
                     select_filter = Some(None);
@@ -1697,6 +1700,7 @@ impl FileDialog {
 
         if let Some(i) = select_filter {
             self.selected_file_filter = i;
+            self.selected_item = None;
         }
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -286,7 +286,7 @@ impl FileDialog {
 
         if let Some(name) = &self.config.default_file_filter {
             for filter in &self.config.file_filters {
-                if &filter.name == name.as_str() {
+                if filter.name == name.as_str() {
                     self.selected_file_filter = Some(filter.id);
                 }
             }
@@ -1786,7 +1786,7 @@ impl FileDialog {
                 .auto_shrink([false, false])
                 .show(ui, |ui| {
                     let data = std::mem::take(&mut self.directory_content);
-                    let file_filter = self.get_selected_file_filter().map(|f| f.clone());
+                    let file_filter = self.get_selected_file_filter().cloned();
 
                     for path in data.filtered_iter(
                         self.config.storage.show_hidden,
@@ -2324,7 +2324,7 @@ impl FileDialog {
 
         let directory_content = std::mem::take(&mut self.directory_content);
         let search_value = std::mem::take(&mut self.search_value);
-        let file_filter = self.get_selected_file_filter().map(|f| f.clone());
+        let file_filter = self.get_selected_file_filter().cloned();
 
         if let Some(index) = directory_content
             .filtered_iter(
@@ -2365,7 +2365,7 @@ impl FileDialog {
 
         let directory_content = std::mem::take(&mut self.directory_content);
         let search_value = std::mem::take(&mut self.search_value);
-        let file_filter = self.get_selected_file_filter().map(|f| f.clone());
+        let file_filter = self.get_selected_file_filter().cloned();
 
         if let Some(index) = directory_content
             .filtered_iter(
@@ -2398,7 +2398,7 @@ impl FileDialog {
     /// Tries to select the first visible item inside `directory_content`.
     fn select_first_visible_item(&mut self) {
         let directory_content = std::mem::take(&mut self.directory_content);
-        let file_filter = self.get_selected_file_filter().map(|f| f.clone());
+        let file_filter = self.get_selected_file_filter().cloned();
 
         if let Some(item) = directory_content
             .filtered_iter(

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1565,16 +1565,33 @@ impl FileDialog {
     fn ui_update_bottom_panel(&mut self, ui: &mut egui::Ui) {
         ui.add_space(5.0);
 
-        // The size of the action buttons "cancel" and "open"/"save"
-        const BUTTON_SIZE: egui::Vec2 = egui::Vec2::new(78.0, 20.0);
+        const BUTTON_HEIGHT: f32 = 20.0;
 
-        self.ui_update_selection_preview(ui, BUTTON_SIZE);
+        // Calculate the width of the action buttons
+        let label_submit_width = match self.mode {
+            DialogMode::SelectDirectory | DialogMode::SelectFile => {
+                Self::calc_text_width(ui, &self.config.labels.open_button)
+            }
+            DialogMode::SaveFile => Self::calc_text_width(ui, &self.config.labels.save_button),
+        };
+
+        let mut btn_width = Self::calc_text_width(ui, &self.config.labels.cancel_button);
+        if label_submit_width > btn_width {
+            btn_width = label_submit_width;
+        }
+
+        btn_width += ui.spacing().button_padding.x * 4.0;
+
+        // The size of the action buttons "cancel" and "open"/"save"
+        let button_size: egui::Vec2 = egui::Vec2::new(btn_width, BUTTON_HEIGHT);
+
+        self.ui_update_selection_preview(ui, button_size);
 
         if self.mode == DialogMode::SaveFile {
             ui.add_space(ui.style().spacing.item_spacing.y * 2.0)
         }
 
-        self.ui_update_action_buttons(ui, BUTTON_SIZE);
+        self.ui_update_action_buttons(ui, button_size);
     }
 
     /// Updates the selection preview like "Selected directory: X"
@@ -1899,6 +1916,16 @@ impl FileDialog {
                 .set_char_range(Some(CCursorRange::one(CCursor::new(data.len()))));
             state.store(&re.ctx, re.id);
         }
+    }
+
+    /// Calculate the width of the specified text using the current font configuration.
+    fn calc_text_width(ui: &egui::Ui, text: &str) -> f32 {
+        let mut width = 0.0;
+        for char in text.chars() {
+            width += ui.fonts(|f| f.glyph_width(&egui::TextStyle::Body.resolve(ui.style()), char));
+        }
+
+        width
     }
 }
 


### PR DESCRIPTION
This PR implements `FileDialog::add_file_filter` which allows adding file filters from the backend, selectable by the user from a dropdown in the bottom right.

Additionally, `FileDialog::default_file_filter` has been implemented to set a file filter that is selected by default.

Example:
```rust
        let file_dialog = FileDialog::default()
            .add_file_filter("PNG files", Arc::new(|p| p.extension().unwrap_or_default() == "png"))
            .add_file_filter("TOML files", Arc::new(|p| p.extension().unwrap_or_default() == "toml"))
            .add_file_filter("Rust source files", Arc::new(|p| p.extension().unwrap_or_default() == "rs"))
            .default_file_filter("TOML files");
```

![Screenshot_20240601_222528](https://github.com/fluxxcode/egui-file-dialog/assets/55352293/f98fdcc7-4b89-42b4-ad8b-c3e8e68c06b5)


Ref: #122 