### PR TITLE
Home directory shortcut

### DIFF
--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -72,6 +72,8 @@ pub struct FileDialogKeyBindings {
     pub new_folder: Vec<KeyBinding>,
     /// Shortcut to text edit the current path
     pub edit_path: Vec<KeyBinding>,
+    /// Shortcut to switch to the home directory and text edit the current path
+    pub home_edit_path: Vec<KeyBinding>,
     /// Shortcut to move the selection one item up
     pub selection_up: Vec<KeyBinding>,
     /// Shortcut to move the selection one item down
@@ -115,6 +117,7 @@ impl Default for FileDialogKeyBindings {
             reload: vec![KeyBinding::key(egui::Key::F5)],
             new_folder: vec![KeyBinding::keyboard_shortcut(Modifiers::CTRL, Key::N)],
             edit_path: vec![KeyBinding::key(Key::Slash)],
+            home_edit_path: vec![KeyBinding::keyboard_shortcut(Modifiers::SHIFT, egui::Key::Backtick)],
             selection_up: vec![KeyBinding::key(Key::ArrowUp)],
             selection_down: vec![KeyBinding::key(Key::ArrowDown)],
         }

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -63,7 +63,7 @@ impl KeyBinding {
                 if any_focused {
                     return false;
                 }
-                
+
                 let mut found_item: Option<usize> = None;
 
                 for (i, text) in i

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -7,6 +7,8 @@ pub enum KeyBinding {
     KeyboardShortcut(egui::KeyboardShortcut),
     /// If a pointer button should be used as the keybinding
     PointerButton(egui::PointerButton),
+    /// If a text event should be used as the keybinding.
+    Text(String),
 }
 
 impl KeyBinding {
@@ -28,6 +30,11 @@ impl KeyBinding {
         Self::PointerButton(pointer_button)
     }
 
+    /// Creates a new keybinding where a text event is used.
+    pub fn text(text: String) -> Self {
+        Self::Text(text)
+    }
+
     /// Checks if the keybinding was pressed by the user.
     ///
     /// # Arguments
@@ -39,9 +46,11 @@ impl KeyBinding {
     ///    keybindings, however, it is desired that when they are pressed, the text fields
     ///    lose focus and the keybinding is executed.
     pub fn pressed(&self, ctx: &egui::Context, ignore_if_any_focused: bool) -> bool {
+        let any_focused = ctx.memory(|r| r.focused()).is_some();
+
         // We want to suppress keyboard input when any other widget like
         // text fields have focus.
-        if ignore_if_any_focused && ctx.memory(|r| r.focused()).is_some() {
+        if ignore_if_any_focused && any_focused {
             return false;
         }
 
@@ -49,6 +58,36 @@ impl KeyBinding {
             KeyBinding::Key(k) => ctx.input(|i| i.key_pressed(*k)),
             KeyBinding::KeyboardShortcut(s) => ctx.input_mut(|i| i.consume_shortcut(s)),
             KeyBinding::PointerButton(b) => ctx.input(|i| i.pointer.button_clicked(*b)),
+            KeyBinding::Text(s) => ctx.input_mut(|i| {
+                // We force to suppress the text events when any other widget has focus
+                if any_focused {
+                    return false;
+                }
+                
+                let mut found_item: Option<usize> = None;
+
+                for (i, text) in i
+                    .events
+                    .iter()
+                    .filter_map(|ev| match ev {
+                        egui::Event::Text(t) => Some(t),
+                        _ => None,
+                    })
+                    .enumerate()
+                {
+                    if text == s {
+                        found_item = Some(i);
+                        break;
+                    }
+                }
+
+                if let Some(index) = found_item {
+                    i.events.remove(index);
+                    return true;
+                }
+
+                false
+            }),
         }
     }
 }
@@ -117,7 +156,10 @@ impl Default for FileDialogKeyBindings {
             reload: vec![KeyBinding::key(egui::Key::F5)],
             new_folder: vec![KeyBinding::keyboard_shortcut(Modifiers::CTRL, Key::N)],
             edit_path: vec![KeyBinding::key(Key::Slash)],
-            home_edit_path: vec![KeyBinding::keyboard_shortcut(Modifiers::SHIFT, egui::Key::Backtick)],
+            home_edit_path: vec![
+                KeyBinding::keyboard_shortcut(Modifiers::SHIFT, egui::Key::Backtick),
+                KeyBinding::text("~".to_string()),
+            ],
             selection_up: vec![KeyBinding::key(Key::ArrowUp)],
             selection_down: vec![KeyBinding::key(Key::ArrowDown)],
         }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1808,6 +1808,15 @@ impl FileDialog {
             self.open_path_edit();
         }
 
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.home_edit_path, false) {
+            if let Some(dirs) = &self.user_directories {
+                if let Some(home) = dirs.home_dir() {
+                    let _ = self.load_directory(&home.to_path_buf());
+                    self.open_path_edit();
+                }
+            }
+        }
+
         if FileDialogKeyBindings::any_pressed(ctx, &keybindings.selection_up, false) {
             self.exec_keybinding_selection_up();
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1250,8 +1250,6 @@ impl FileDialog {
             return;
         }
 
-        // Whether to activate the text input widget
-        let mut activate = false;
         ui.input(|inp| {
             // We stop if any modifier is active besides only shift
             if inp.modifiers.any() && !inp.modifiers.shift_only() {
@@ -1265,13 +1263,9 @@ impl FileDialog {
                 _ => None,
             }) {
                 self.search_value.push_str(text);
-                activate = true;
+                self.init_search = true;
             }
         });
-
-        if activate {
-            self.init_search = true;
-        }
     }
 
     /// Updates the left panel of the dialog. Including the list of the user directories (Places)

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1808,7 +1808,7 @@ impl FileDialog {
             self.open_path_edit();
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.home_edit_path, false) {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.home_edit_path, true) {
             if let Some(dirs) = &self.user_directories {
                 if let Some(home) = dirs.home_dir() {
                     let _ = self.load_directory(&home.to_path_buf());

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1811,7 +1811,7 @@ impl FileDialog {
         if FileDialogKeyBindings::any_pressed(ctx, &keybindings.home_edit_path, true) {
             if let Some(dirs) = &self.user_directories {
                 if let Some(home) = dirs.home_dir() {
-                    let _ = self.load_directory(&home.to_path_buf());
+                    let _ = self.load_directory(home.to_path_buf().as_path());
                     self.open_path_edit();
                 }
             }


### PR DESCRIPTION
Added new shortcut `~` that loads the home directory and begins text editing of the current path.

Since eframe only handles this keyboard input as a text event, the new keybinding type `Text` was added.

Ref #116 