### PR TITLE
Implement multi selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased - v0.6.0
 ### 🚨 Breaking Changes
-- Added new labels to `FileDialogLabels` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100), [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111)
+- Added `DialogMode::SelectMultiple` and `DialogState::SelectedMultiple` [#127](https://github.com/fluxxcode/egui-file-dialog/pull/127)
+- Added new labels to `FileDialogLabels` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100), [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111), [#127](https://github.com/fluxxcode/egui-file-dialog/pull/127)
 - Added new configuration values to `FileDialogConfig` [#100](https://github.com/fluxxcode/egui-file-dialog/pull/100), [#104](https://github.com/fluxxcode/egui-file-dialog/pull/104), [#106](https://github.com/fluxxcode/egui-file-dialog/pull/106), [#110](https://github.com/fluxxcode/egui-file-dialog/pull/110), [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111), [#118](https://github.com/fluxxcode/egui-file-dialog/pull/118)
 
 ### ✨ Features
@@ -13,6 +14,7 @@
 - Implemented show hidden files and folders option [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111)
 - The dialog is now displayed as a modal window by default. This can be disabled with `FileDialog::as_modal`. The color of the modal overlay can be adjusted using `FileDialog::modal_overlay_color`. [#118](https://github.com/fluxxcode/egui-file-dialog/pull/118)
 - Added `FileDialog::add_file_filter` and `FileDialog::default_file_filter` to add file filters that can be selected by the user from a drop-down menu at the bottom [#124](https://github.com/fluxxcode/egui-file-dialog/pull/124)
+- Implemented selection of multiple files and folders at once, using `FileDialog::select_multiple`, `FileDialog::selected_multiple` and `FileDialog::take_selected_multiple` [#127]([#127](https://github.com/fluxxcode/egui-file-dialog/pull/127))
 
 ### ☢️ Deprecated
 - Deprecated `FileDialog::overwrite_config`. Use `FileDialog::with_config` and `FileDialog::config_mut` instead [#103](https://github.com/fluxxcode/egui-file-dialog/pull/103)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Implemented show hidden files and folders option [#111](https://github.com/fluxxcode/egui-file-dialog/pull/111)
 - The dialog is now displayed as a modal window by default. This can be disabled with `FileDialog::as_modal`. The color of the modal overlay can be adjusted using `FileDialog::modal_overlay_color`. [#118](https://github.com/fluxxcode/egui-file-dialog/pull/118)
 - Added `FileDialog::add_file_filter` and `FileDialog::default_file_filter` to add file filters that can be selected by the user from a drop-down menu at the bottom [#124](https://github.com/fluxxcode/egui-file-dialog/pull/124)
-- Implemented selection of multiple files and folders at once, using `FileDialog::select_multiple`, `FileDialog::selected_multiple` and `FileDialog::take_selected_multiple` [#127]([#127](https://github.com/fluxxcode/egui-file-dialog/pull/127))
+- Implemented selection of multiple files and folders at once, using `FileDialog::select_multiple`, `FileDialog::selected_multiple` and `FileDialog::take_selected_multiple` [#127](https://github.com/fluxxcode/egui-file-dialog/pull/127)
 
 ### ☢️ Deprecated
 - Deprecated `FileDialog::overwrite_config`. Use `FileDialog::with_config` and `FileDialog::config_mut` instead [#103](https://github.com/fluxxcode/egui-file-dialog/pull/103)

--- a/examples/multilingual/src/main.rs
+++ b/examples/multilingual/src/main.rs
@@ -13,6 +13,7 @@ fn get_labels_german() -> FileDialogLabels {
     FileDialogLabels {
         title_select_directory: "📁 Ordner Öffnen".to_string(),
         title_select_file: "📂 Datei Öffnen".to_string(),
+        title_select_multiple: "🗐 Mehrere Öffnen".to_string(),
         title_save_file: "📥 Datei Speichern".to_string(),
 
         cancel: "Abbrechen".to_string(),

--- a/examples/multilingual/src/main.rs
+++ b/examples/multilingual/src/main.rs
@@ -40,6 +40,7 @@ fn get_labels_german() -> FileDialogLabels {
 
         selected_directory: "Ausgewählter Ordner:".to_string(),
         selected_file: "Ausgewählte Datei:".to_string(),
+        selected_items: "Ausgewählte Elemente:".to_string(),
         file_name: "Dateiname:".to_string(),
         file_filter_all_files: "Alle Dateien".to_string(),
 

--- a/examples/sandbox/src/main.rs
+++ b/examples/sandbox/src/main.rs
@@ -8,6 +8,7 @@ struct MyApp {
 
     selected_directory: Option<PathBuf>,
     selected_file: Option<PathBuf>,
+    selected_multiple: Option<Vec<PathBuf>>,
     saved_file: Option<PathBuf>,
 }
 
@@ -43,6 +44,7 @@ impl MyApp {
 
             selected_directory: None,
             selected_file: None,
+            selected_multiple: None,
             saved_file: None,
         }
     }
@@ -76,6 +78,19 @@ impl eframe::App for MyApp {
             }
             ui.label(format!("Selected file: {:?}", self.selected_file));
 
+            if ui.button("Select multiple").clicked() {
+                self.file_dialog.select_multiple();
+            }
+            ui.label("Selected multiple:");
+
+            if let Some(items) = &self.selected_multiple {
+                for item in items {
+                    ui.label(format!("{:?}", item));
+                }
+            } else {
+                ui.label("None");
+            }
+
             ui.add_space(5.0);
 
             if ui.button("Save file").clicked() {
@@ -90,7 +105,12 @@ impl eframe::App for MyApp {
                     DialogMode::SelectDirectory => self.selected_directory = Some(path),
                     DialogMode::SelectFile => self.selected_file = Some(path),
                     DialogMode::SaveFile => self.saved_file = Some(path),
+                    _ => {}
                 }
+            }
+
+            if let Some(items) = self.file_dialog.take_selected_multiple() {
+                self.selected_multiple = Some(items);
             }
         });
     }

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -117,6 +117,8 @@ pub struct FileDialogKeyBindings {
     pub selection_up: Vec<KeyBinding>,
     /// Shortcut to move the selection one item down
     pub selection_down: Vec<KeyBinding>,
+    /// Shortcut to select every item when the dialog is in `DialogMode::SelectMultiple` mode
+    pub select_all: Vec<KeyBinding>,
 }
 
 impl FileDialogKeyBindings {
@@ -162,6 +164,7 @@ impl Default for FileDialogKeyBindings {
             ],
             selection_up: vec![KeyBinding::key(Key::ArrowUp)],
             selection_down: vec![KeyBinding::key(Key::ArrowDown)],
+            select_all: vec![KeyBinding::keyboard_shortcut(Modifiers::CTRL, Key::A)],
         }
     }
 }

--- a/src/config/labels.rs
+++ b/src/config/labels.rs
@@ -27,6 +27,8 @@ pub struct FileDialogLabels {
     pub title_select_directory: String,
     /// The default window title used when the dialog is in `DialogMode::SelectFile` mode.
     pub title_select_file: String,
+    /// The default window title used when the dialog is in `DialogMode::SelectMultiple` mode.
+    pub title_select_multiple: String,
     /// The default window title used when the dialog is in `DialogMode::SaveFile` mode.
     pub title_save_file: String,
 
@@ -116,6 +118,7 @@ impl Default for FileDialogLabels {
         Self {
             title_select_directory: "📁 Select Folder".to_string(),
             title_select_file: "📂 Open File".to_string(),
+            title_select_multiple: "🗐 Select Multiple".to_string(),
             title_save_file: "📥 Save File".to_string(),
 
             cancel: "Cancel".to_string(),

--- a/src/config/labels.rs
+++ b/src/config/labels.rs
@@ -83,6 +83,8 @@ pub struct FileDialogLabels {
     pub selected_directory: String,
     /// Text that appears in front of the selected file preview in the bottom panel.
     pub selected_file: String,
+    /// Text that appears in front of the selected items preview in the bottom panel.
+    pub selected_items: String,
     /// Text that appears in front of the file name input in the bottom panel.
     pub file_name: String,
     /// Text displayed in the file filter dropdown for the "All Files" option.
@@ -145,6 +147,7 @@ impl Default for FileDialogLabels {
 
             selected_directory: "Selected directory:".to_string(),
             selected_file: "Selected file:".to_string(),
+            selected_items: "Selected items:".to_string(),
             file_name: "File name:".to_string(),
             file_filter_all_files: "All Files".to_string(),
 

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -6,7 +6,7 @@ use crate::config::{FileDialogConfig, FileFilter};
 /// Contains the metadata of a directory item.
 /// This struct is mainly there so that the metadata can be loaded once and not that
 /// a request has to be sent to the OS every frame using, for example, `path.is_file()`.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DirectoryEntry {
     path: PathBuf,
@@ -27,6 +27,11 @@ impl DirectoryEntry {
             icon: gen_path_icon(config, path),
             selected: false,
         }
+    }
+
+    /// Checks if the path of the current directory entry matches the other directory entry.
+    pub fn path_eq(&self, other: &DirectoryEntry) -> bool {
+        other.as_path() == self.as_path()
     }
 
     /// Returns true if the item is a directory.

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -13,6 +13,8 @@ pub struct DirectoryEntry {
     is_directory: bool,
     is_system_file: bool,
     icon: String,
+    /// If the item is marked as selected as part of a multi selection.
+    pub selected: bool,
 }
 
 impl DirectoryEntry {
@@ -23,6 +25,7 @@ impl DirectoryEntry {
             is_directory: path.is_dir(),
             is_system_file: !path.is_dir() && !path.is_file(),
             icon: gen_path_icon(config, path),
+            selected: false,
         }
     }
 
@@ -163,6 +166,23 @@ impl DirectoryContent {
         self.content
             .iter()
             .filter(move |p| Self::is_entry_visible(p, show_hidden, search_value, file_filter))
+    }
+
+    pub fn filtered_iter_mut<'s>(
+        &'s mut self,
+        show_hidden: bool,
+        search_value: &'s str,
+        file_filter: Option<&'s FileFilter>,
+    ) -> impl Iterator<Item = &mut DirectoryEntry> + 's {
+        self.content
+            .iter_mut()
+            .filter(move |p| Self::is_entry_visible(p, show_hidden, search_value, file_filter))
+    }
+
+    pub fn reset_multi_selection(&mut self) {
+        for item in self.content.iter_mut() {
+            item.selected = false;
+        }
     }
 
     /// Returns the number of elements inside the directory.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2230,6 +2230,16 @@ impl FileDialog {
             }
         }
 
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.select_all, true) {
+            for item in self.directory_content.filtered_iter_mut(
+                self.config.storage.show_hidden,
+                &self.search_value,
+                self.get_selected_file_filter().cloned().as_ref(),
+            ) {
+                item.selected = true;
+            }
+        }
+
         self.config.keybindings = keybindings;
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1658,8 +1658,7 @@ impl FileDialog {
         let item_spacing = ui.style().spacing.item_spacing;
 
         let render_filter_selection = !self.config.file_filters.is_empty()
-            && self.mode == DialogMode::SelectFile
-            || self.mode == DialogMode::SelectMultiple;
+            && (self.mode == DialogMode::SelectFile || self.mode == DialogMode::SelectMultiple);
 
         let filter_selection_width = button_size.x * 2.0 + item_spacing.x;
         let mut filter_selection_separate_line = false;

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1836,34 +1836,34 @@ impl FileDialog {
 
                     let mut reset_multi_selection = false;
 
-                    for path in data.filtered_iter_mut(
+                    for item in data.filtered_iter_mut(
                         self.config.storage.show_hidden,
                         &self.search_value.clone(),
                         file_filter.as_ref(),
                     ) {
-                        let file_name = path.file_name();
+                        let file_name = item.file_name();
 
                         let mut primary_selected = false;
                         if let Some(x) = &self.selected_item {
-                            primary_selected = x == path;
+                            primary_selected = x == item;
                         }
 
-                        let pinned = self.is_pinned(path);
+                        let pinned = self.is_pinned(item);
                         let label = match pinned {
                             true => {
-                                format!("{} {} {}", path.icon(), self.config.pinned_icon, file_name)
+                                format!("{} {} {}", item.icon(), self.config.pinned_icon, file_name)
                             }
-                            false => format!("{} {}", path.icon(), file_name),
+                            false => format!("{} {}", item.icon(), file_name),
                         };
 
                         let response =
-                            ui.selectable_label(primary_selected || path.selected, label);
+                            ui.selectable_label(primary_selected || item.selected, label);
 
-                        if path.is_dir() {
-                            self.ui_update_path_context_menu(&response, path);
+                        if item.is_dir() {
+                            self.ui_update_path_context_menu(&response, item);
 
                             if response.context_menu_opened() {
-                                self.select_item(path.clone());
+                                self.select_item(item.clone());
                             }
                         }
 
@@ -1874,7 +1874,7 @@ impl FileDialog {
 
                         // The user wants to select the item as the primary selected item
                         if response.clicked() && !ui.input(|i| i.modifiers.ctrl) {
-                            self.select_item(path.clone());
+                            self.select_item(item.clone());
                             reset_multi_selection = true;
                         }
 
@@ -1885,20 +1885,20 @@ impl FileDialog {
                             && ui.input(|i| i.modifiers.ctrl)
                         {
                             if primary_selected {
-                                path.selected = false;
+                                item.selected = false;
                                 self.selected_item = None;
                             } else {
-                                path.selected = !path.selected;
+                                item.selected = !item.selected;
                             }
                         }
 
                         if response.double_clicked() && !ui.input(|i| i.modifiers.ctrl) {
-                            if path.is_dir() {
-                                let _ = self.load_directory(&path.to_path_buf());
+                            if item.is_dir() {
+                                let _ = self.load_directory(&item.to_path_buf());
                                 return;
                             }
 
-                            self.select_item(path.clone());
+                            self.select_item(item.clone());
 
                             self.submit();
                         }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1808,6 +1808,7 @@ impl FileDialog {
         if let Some(i) = select_filter {
             self.selected_file_filter = i;
             self.selected_item = None;
+            self.directory_content.reset_multi_selection();
         }
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2580,6 +2580,8 @@ impl FileDialog {
     fn select_next_visible_item_before(&mut self, item: &DirectoryEntry) -> bool {
         let mut return_val = false;
 
+        self.directory_content.reset_multi_selection();
+
         let mut directory_content = std::mem::take(&mut self.directory_content);
         let search_value = std::mem::take(&mut self.search_value);
         let file_filter = self.get_selected_file_filter().cloned();
@@ -2622,6 +2624,8 @@ impl FileDialog {
     fn select_next_visible_item_after(&mut self, item: &DirectoryEntry) -> bool {
         let mut return_val = false;
 
+        self.directory_content.reset_multi_selection();
+
         let mut directory_content = std::mem::take(&mut self.directory_content);
         let search_value = std::mem::take(&mut self.search_value);
         let file_filter = self.get_selected_file_filter().cloned();
@@ -2657,6 +2661,8 @@ impl FileDialog {
 
     /// Tries to select the first visible item inside `directory_content`.
     fn select_first_visible_item(&mut self) {
+        self.directory_content.reset_multi_selection();
+
         let mut directory_content = std::mem::take(&mut self.directory_content);
 
         if let Some(item) = directory_content
@@ -2676,6 +2682,8 @@ impl FileDialog {
 
     /// Tries to select the last visible item inside `directory_content`.
     fn select_last_visible_item(&mut self) {
+        self.directory_content.reset_multi_selection();
+
         let mut directory_content = std::mem::take(&mut self.directory_content);
 
         if let Some(item) = directory_content

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2616,8 +2616,7 @@ impl FileDialog {
                 &search_value,
                 file_filter.as_ref(),
             )
-            .position(|p| p.path_eq(item))
-            .clone();
+            .position(|p| p.path_eq(item));
 
         if let Some(index) = index {
             if let Some(item) = directory_content

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1658,7 +1658,7 @@ impl FileDialog {
         let item_spacing = ui.style().spacing.item_spacing;
 
         let render_filter_selection =
-            !self.config.file_filters.is_empty() && self.mode == DialogMode::SelectFile;
+            !self.config.file_filters.is_empty() && self.mode == DialogMode::SelectFile || self.mode == DialogMode::SelectMultiple;
 
         let filter_selection_width = button_size.x * 2.0 + item_spacing.x;
         let mut filter_selection_separate_line = false;

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2250,7 +2250,9 @@ impl FileDialog {
         // Check if there is a directory selected we can open
         if let Some(item) = &self.selected_item {
             // Make sure the selected item is visible inside the directory view.
-            let is_visible = self.get_dir_content_filtered_iter().any(|p| p.path_eq(item));
+            let is_visible = self
+                .get_dir_content_filtered_iter()
+                .any(|p| p.path_eq(item));
 
             if is_visible && item.is_dir() {
                 let _ = self.load_directory(&item.to_path_buf());
@@ -2440,7 +2442,8 @@ impl FileDialog {
                 }
             }
             DialogMode::SelectMultiple => {
-                let result: Vec<PathBuf> = self.get_dir_content_filtered_iter()
+                let result: Vec<PathBuf> = self
+                    .get_dir_content_filtered_iter()
                     .filter(|p| p.selected)
                     .map(|p| p.to_path_buf())
                     .collect();
@@ -2514,9 +2517,7 @@ impl FileDialog {
                     false
                 }
             }
-            DialogMode::SelectMultiple => {
-                self.get_dir_content_filtered_iter().any(|p| p.selected)
-            }
+            DialogMode::SelectMultiple => self.get_dir_content_filtered_iter().any(|p| p.selected),
             DialogMode::SaveFile => self.file_name_input_error.is_none(),
         }
     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1657,8 +1657,9 @@ impl FileDialog {
         const SELECTION_PREVIEW_MIN_WIDTH: f32 = 50.0;
         let item_spacing = ui.style().spacing.item_spacing;
 
-        let render_filter_selection =
-            !self.config.file_filters.is_empty() && self.mode == DialogMode::SelectFile || self.mode == DialogMode::SelectMultiple;
+        let render_filter_selection = !self.config.file_filters.is_empty()
+            && self.mode == DialogMode::SelectFile
+            || self.mode == DialogMode::SelectMultiple;
 
         let filter_selection_width = button_size.x * 2.0 + item_spacing.x;
         let mut filter_selection_separate_line = false;

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1786,9 +1786,9 @@ impl FileDialog {
     fn ui_update_action_buttons(&mut self, ui: &mut egui::Ui, button_size: egui::Vec2) {
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
             let label = match &self.mode {
-                DialogMode::SelectDirectory | DialogMode::SelectFile | DialogMode::SelectMultiple => {
-                    self.config.labels.open_button.as_str()
-                }
+                DialogMode::SelectDirectory
+                | DialogMode::SelectFile
+                | DialogMode::SelectMultiple => self.config.labels.open_button.as_str(),
                 DialogMode::SaveFile => self.config.labels.save_button.as_str(),
             };
 


### PR DESCRIPTION
Implemented feature to select multiple files and folders at once.

Breaking Changes:
- Added `DialogMode::SelectMultiple`
- Added `DialogState::SelectedMultiple`
- Added new labels to `FileDialogLabels`
- Removed `PartialEq, Eq` implementation from `DirectoryEntry`, use `DirectoryEntry::path_eq` instead

Non breaking changes:
- Added `FileDialog::select_multiple`
- Added `FileDialog::selected_multiple`
- Added `FileDialog::take_selected_multiple`
- Added Keybinding `select_all`