### PR TITLE
FileDialog is not Send

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -357,7 +357,7 @@ impl FileDialogConfig {
 }
 
 /// Function that returns true if the specific item matches the filter.
-pub type Filter<T> = Arc<dyn Fn(&T) -> bool>;
+pub type Filter<T> = Arc<dyn Fn(&T) -> bool + Send + Sync>;
 
 /// Defines a specific file filter that the user can select from a dropdown.
 #[derive(Clone)]

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -158,8 +158,8 @@ pub struct FileDialog {
 }
 
 /// this tests if file dialog is send.
-#[test]
 fn test_prop<T: Send>() {}
+#[test]
 fn test() {
     test_prop::<FileDialog>()
 }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::{fs, io};
 
 use egui::text::{CCursor, CCursorRange};
+use sysinfo::User;
 
 use crate::config::{
     FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, FileDialogStorage, FileFilter,
@@ -77,7 +78,7 @@ pub struct FileDialog {
 
     /// Stack of modal windows to be displayed.
     /// The top element is what is currently being rendered.
-    modals: Vec<Box<dyn FileDialogModal>>,
+    modals: Vec<Box<dyn FileDialogModal + Send>>,
 
     /// The mode the dialog is currently in
     mode: DialogMode,
@@ -154,6 +155,13 @@ pub struct FileDialog {
     /// This is used to prevent the dialog from closing when pressing the escape key
     /// inside a text input.
     any_focused_last_frame: bool,
+}
+
+/// this tests if file dialog is send.
+#[test]
+fn test_prop<T: Send>() {}
+fn test() {
+    test_prop::<FileDialog>()
 }
 
 impl Default for FileDialog {
@@ -2389,7 +2397,7 @@ impl FileDialog {
     }
 
     /// Opens a new modal window.
-    fn open_modal(&mut self, modal: Box<dyn FileDialogModal>) {
+    fn open_modal(&mut self, modal: Box<dyn FileDialogModal + Send>) {
         self.modals.push(modal);
     }
 


### PR DESCRIPTION
File Dialog doesnt implement the Send Bound. this is not a bug but limiting the use of FileDialog.
Not beeing Send means that it can not be used in a Mutex or across multiple threads.

I found this restriction unnecessaryly strict and changed it.
this only required a few trait bounds to be changed, nothing else in the source code.

please feel free to merge this request.