### PR TITLE
Fix select_all keybinding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # egui-file-dialog changelog
 
 ## Unreleased
+- Fixed that the `select_all` keybinding can also be used in `DialogMode`'s in which only one item can be selected [#142](https://github.com/fluxxcode/egui-file-dialog/pull/142)
+
 ### 🔧 Changes
 - Updated `sysinfo` from version `0.30.5` to `0.31` [#140](https://github.com/fluxxcode/egui-file-dialog/pull/140)
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2250,7 +2250,9 @@ impl FileDialog {
             }
         }
 
-        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.select_all, true) {
+        if FileDialogKeyBindings::any_pressed(ctx, &keybindings.select_all, true)
+            && self.mode == DialogMode::SelectMultiple
+        {
             for item in self.directory_content.filtered_iter_mut(
                 self.config.storage.show_hidden,
                 &self.search_value,


### PR DESCRIPTION
Fixed that the `select_all` keybinding can also be used in the `DialogMode`'s in which only one item can be selected.