### PR TITLE
Select file from path edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # egui-file-dialog changelog
 
+## Unreleased
+### 🔧 Changes
+- Path edit is now selected as the desired file if the path entered is an existing file and the dialog is in `DialogueMode::SelectFile` mode. [#151](https://github.com/fluxxcode/egui-file-dialog/pull/151)
+
 ## 2024-09-10 - v0.6.1 - Bug Fixes
 ### 🐛 Bug Fixes
 - Fixed that the `select_all` keybinding can also be used in `DialogMode`'s in which only one item can be selected [#142](https://github.com/fluxxcode/egui-file-dialog/pull/142)

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2743,6 +2743,13 @@ impl FileDialog {
     /// Loads the directory from the path text edit.
     fn submit_path_edit(&mut self) {
         self.close_path_edit();
+
+        let path = self.canonicalize_path(&PathBuf::from(&self.path_edit_value));
+        if self.mode == DialogMode::SelectFile && path.is_file() {
+            self.state = DialogState::Selected(path);
+            return;
+        }
+
         let _ = self.load_directory(&self.canonicalize_path(&PathBuf::from(&self.path_edit_value)));
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2745,12 +2745,13 @@ impl FileDialog {
         self.close_path_edit();
 
         let path = self.canonicalize_path(&PathBuf::from(&self.path_edit_value));
+
         if self.mode == DialogMode::SelectFile && path.is_file() {
             self.state = DialogState::Selected(path);
             return;
         }
 
-        let _ = self.load_directory(&self.canonicalize_path(&PathBuf::from(&self.path_edit_value)));
+        let _ = self.load_directory(&path);
     }
 
     /// Closes the text field at the top to edit the current path without loading


### PR DESCRIPTION
When the dialog is used to select a file, the path edit is now selected if the specified path is a file.

Closes: #150 