### PR TITLE
Save path from path edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # egui-file-dialog changelog
 
+## Unreleased
+### 🔧 Changes
+- Use path edit as file to save [#160](https://github.com/fluxxcode/egui-file-dialog/pull/160)
+
 ## 2024-10-01 - v0.7.0 - egui update and QoL changes
 ### 🚨 Breaking Changes
 - Updated `egui` from version `0.28.0` to version `0.29.1` [#155](https://github.com/fluxxcode/egui-file-dialog/pull/155) and [#157](https://github.com/fluxxcode/egui-file-dialog/pull/157) (thanks [@crumblingstatue](https://github.com/crumblingstatue)!)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -84,6 +84,15 @@ pub struct FileDialogConfig {
     /// If the user is allowed to select an already existing file when the dialog is
     /// in `DialogMode::SaveFile` mode.
     pub allow_file_overwrite: bool,
+    /// If the path edit is allowed to select the path as the file to save
+    /// if it does not have an extension.
+    ///
+    /// This can lead to confusion if the user wants to open a directory with the path edit,
+    /// types it incorrectly and the dialog tries to select the incorrectly typed folder as
+    /// the file to be saved.
+    ///
+    /// This only affects the `DialogMode::SaveFile` mode.
+    pub allow_path_edit_to_save_file_without_extension: bool,
     /// Sets the separator of the directories when displaying a path.
     /// Currently only used when the current path is displayed in the top panel.
     pub directory_separator: String,
@@ -196,6 +205,7 @@ impl Default for FileDialogConfig {
             initial_directory: std::env::current_dir().unwrap_or_default(),
             default_file_name: String::new(),
             allow_file_overwrite: true,
+            allow_path_edit_to_save_file_without_extension: false,
             directory_separator: String::from(">"),
             canonicalize_paths: true,
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2771,7 +2771,7 @@ impl FileDialog {
         if self.mode == DialogMode::SaveFile
             && path.extension().is_some()
             && !path.is_dir()
-            && path.parent().is_some_and(|p| p.exists())
+            && path.parent().is_some_and(std::path::Path::exists)
         {
             self.submit_save_file(path);
             return;

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2764,9 +2764,9 @@ impl FileDialog {
         }
 
         // Assume the user wants to save the given path when
-        //   - An extension to the file name is given
-        //   - The path is not an existing directory
-        //   - The parent directory exists
+        //   - an extension to the file name is given,
+        //   - the path is not an existing directory,
+        //   - and the parent directory exists
         // Otherwise we will assume the user wants to open the path as a directory.
         if self.mode == DialogMode::SaveFile
             && path.extension().is_some()

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -540,6 +540,19 @@ impl FileDialog {
         self
     }
 
+    /// Sets if the path edit is allowed to select the path as the file to save
+    /// if it does not have an extension.
+    ///
+    /// This can lead to confusion if the user wants to open a directory with the path edit,
+    /// types it incorrectly and the dialog tries to select the incorrectly typed folder as
+    /// the file to be saved.
+    ///
+    /// This only affects the `DialogMode::SaveFile` mode.
+    pub const fn allow_path_edit_to_save_file_without_extension(mut self, allow: bool) -> Self {
+        self.config.allow_path_edit_to_save_file_without_extension = allow;
+        self
+    }
+
     /// Sets the separator of the directories when displaying a path.
     /// Currently only used when the current path is displayed in the top panel.
     pub fn directory_separator(mut self, separator: &str) -> Self {
@@ -2764,12 +2777,14 @@ impl FileDialog {
         }
 
         // Assume the user wants to save the given path when
-        //   - an extension to the file name is given,
+        //   - an extension to the file name is given or the path
+        //     edit is allowed to save a file without extension,
         //   - the path is not an existing directory,
         //   - and the parent directory exists
         // Otherwise we will assume the user wants to open the path as a directory.
         if self.mode == DialogMode::SaveFile
-            && path.extension().is_some()
+            && (path.extension().is_some()
+                || self.config.allow_path_edit_to_save_file_without_extension)
             && !path.is_dir()
             && path.parent().is_some_and(std::path::Path::exists)
         {


### PR DESCRIPTION
When the dialog is in file save mode, the path edit is used as the expected file to save if:
  - an extension is specified,
  - the path is not an existing directory,
  - and the parent path exists.

Closes #159 