### PR TITLE
Filter directory when loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Use path edit as file to save [#160](https://github.com/fluxxcode/egui-file-dialog/pull/160)
 - Updated sysinfo to version `0.32` [#161](https://github.com/fluxxcode/egui-file-dialog/pull/161)
 - Made default egui fonts an optional feature `default_fonts` [#163](https://github.com/fluxxcode/egui-file-dialog/pull/163) (thanks [@StarStarJ](https://github.com/StarStarJ)!)
+- Filter directory when loading to improve performance [#169](https://github.com/fluxxcode/egui-file-dialog/pull/169)
 
 ## 2024-10-01 - v0.7.0 - egui update and QoL changes
 ### 🚨 Breaking Changes

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -140,14 +140,18 @@ impl DirectoryContent {
         &'s self,
         search_value: &'s str,
     ) -> impl Iterator<Item = &'s DirectoryEntry> + 's {
-        self.content.iter().filter(|p| apply_search_value(p, search_value))
+        self.content
+            .iter()
+            .filter(|p| apply_search_value(p, search_value))
     }
 
     pub fn filtered_iter_mut<'s>(
         &'s mut self,
         search_value: &'s str,
     ) -> impl Iterator<Item = &'s mut DirectoryEntry> + 's {
-        self.content.iter_mut().filter(|p| apply_search_value(p, search_value))
+        self.content
+            .iter_mut()
+            .filter(|p| apply_search_value(p, search_value))
     }
 
     pub fn reset_multi_selection(&mut self) {
@@ -173,7 +177,11 @@ impl DirectoryContent {
 }
 
 fn apply_search_value(entry: &DirectoryEntry, value: &str) -> bool {
-    value.is_empty() || entry.file_name().to_lowercase().contains(&value.to_lowercase())
+    value.is_empty()
+        || entry
+            .file_name()
+            .to_lowercase()
+            .contains(&value.to_lowercase())
 }
 
 /// Loads the contents of the given directory.

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -140,24 +140,14 @@ impl DirectoryContent {
         &'s self,
         search_value: &'s str,
     ) -> impl Iterator<Item = &'s DirectoryEntry> + 's {
-        self.content.iter().filter(|p| {
-            search_value.is_empty()
-                || p.file_name()
-                    .to_lowercase()
-                    .contains(&search_value.to_lowercase())
-        })
+        self.content.iter().filter(|p| apply_search_value(p, search_value))
     }
 
     pub fn filtered_iter_mut<'s>(
         &'s mut self,
         search_value: &'s str,
     ) -> impl Iterator<Item = &'s mut DirectoryEntry> + 's {
-        self.content.iter_mut().filter(|p| {
-            search_value.is_empty()
-                || p.file_name()
-                    .to_lowercase()
-                    .contains(&search_value.to_lowercase())
-        })
+        self.content.iter_mut().filter(|p| apply_search_value(p, search_value))
     }
 
     pub fn reset_multi_selection(&mut self) {
@@ -180,6 +170,10 @@ impl DirectoryContent {
     pub fn clear(&mut self) {
         self.content.clear();
     }
+}
+
+fn apply_search_value(entry: &DirectoryEntry, value: &str) -> bool {
+    value.is_empty() || entry.file_name().to_lowercase().contains(&value.to_lowercase())
 }
 
 /// Loads the contents of the given directory.


### PR DESCRIPTION
Changed so that the file filter and "show hidden files option" are applied when the directory loads rather than every frame. This should improve performance, especially on Windows.

The text search is  still applied every frame. Implementing this differently is not easy either. We can't reload the directory every time the text field changes, otherwise the usability will suffer, especially for large directories and slow disks.
However, with 50,000 items in a directory, there will be no significant performance issues if this is done every frame.

Ref #168 