### PR TITLE
Add `FileDialog::{active_entry, update_with_custom_right_panel}`

### DIFF
--- a/examples/custom-right-panel/Cargo.toml
+++ b/examples/custom-right-panel/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "custom-right-panel"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+eframe = { workspace = true }
+egui-file-dialog = { path = "../../"}

--- a/examples/custom-right-panel/src/main.rs
+++ b/examples/custom-right-panel/src/main.rs
@@ -1,7 +1,7 @@
-use {egui_file_dialog::DialogMode, std::path::PathBuf};
+use std::path::PathBuf;
 
 use eframe::egui;
-use egui_file_dialog::FileDialog;
+use egui_file_dialog::{DialogMode, FileDialog};
 
 struct MyApp {
     file_dialog: FileDialog,

--- a/examples/custom-right-panel/src/main.rs
+++ b/examples/custom-right-panel/src/main.rs
@@ -1,0 +1,91 @@
+use std::path::PathBuf;
+
+use eframe::egui;
+use egui_file_dialog::FileDialog;
+
+struct MyApp {
+    file_dialog: FileDialog,
+    selected_items: Option<Vec<PathBuf>>,
+    mode: SelMode,
+}
+
+enum SelMode {
+    Single,
+    Multiple,
+}
+
+impl MyApp {
+    pub fn new(_cc: &eframe::CreationContext) -> Self {
+        Self {
+            file_dialog: FileDialog::new(),
+            selected_items: None,
+            mode: SelMode::Single,
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            if ui.button("Select single").clicked() {
+                self.mode = SelMode::Single;
+                self.file_dialog.select_file();
+            }
+            if ui.button("Select multiple").clicked() {
+                self.mode = SelMode::Multiple;
+                self.file_dialog.select_multiple();
+            }
+
+            ui.label("Selected items:");
+
+            if let Some(items) = &self.selected_items {
+                for item in items {
+                    ui.label(format!("{:?}", item));
+                }
+            } else {
+                ui.label("None");
+            }
+
+            self.file_dialog
+                .update_with_right_panel_ui(ctx, &mut |ui, dia| match self.mode {
+                    SelMode::Single => {
+                        ui.heading("Active item");
+                        ui.small(format!("{:#?}", dia.active_entry()));
+                    }
+                    SelMode::Multiple => {
+                        ui.heading("Selected items");
+                        ui.separator();
+                        egui::ScrollArea::vertical()
+                            .max_height(ui.available_height())
+                            .show(ui, |ui| {
+                                for item in dia.active_selected_entries() {
+                                    ui.small(format!("{item:#?}"));
+                                    ui.separator();
+                                }
+                            });
+                    }
+                });
+
+            match self.mode {
+                SelMode::Single => {
+                    if let Some(item) = self.file_dialog.take_selected() {
+                        self.selected_items = Some(vec![item]);
+                    }
+                }
+                SelMode::Multiple => {
+                    if let Some(items) = self.file_dialog.take_selected_multiple() {
+                        self.selected_items = Some(items);
+                    }
+                }
+            }
+        });
+    }
+}
+
+fn main() -> eframe::Result<()> {
+    eframe::run_native(
+        "File dialog example",
+        eframe::NativeOptions::default(),
+        Box::new(|ctx| Ok(Box::new(MyApp::new(ctx)))),
+    )
+}

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1004,6 +1004,13 @@ impl FileDialog {
         self.selected_item.as_ref()
     }
 
+    /// Returns an iterator over the currently selected entries in [`SelectMultiple`] mode.
+    ///
+    /// [`SelectMultiple`]: DialogMode::SelectMultiple
+    pub fn active_selected_entries(&self) -> impl Iterator<Item = &DirectoryEntry> {
+        self.get_dir_content_filtered_iter().filter(|p| p.selected)
+    }
+
     /// Returns the ID of the operation for which the dialog is currently being used.
     ///
     /// See `FileDialog::open` for more information.
@@ -2580,13 +2587,6 @@ impl FileDialog {
                 }
             }
         }
-    }
-
-    /// Returns an iterator over the currently selected entries in [`SelectMultiple`] mode.
-    ///
-    /// [`SelectMultiple`]: DialogMode::SelectMultiple
-    pub fn active_selected_entries(&self) -> impl Iterator<Item = &DirectoryEntry> {
-        self.get_dir_content_filtered_iter().filter(|p| p.selected)
     }
 
     /// Submits the file dialog with the specified path and opens the `OverwriteFileModal`

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2565,8 +2565,7 @@ impl FileDialog {
             }
             DialogMode::SelectMultiple => {
                 let result: Vec<PathBuf> = self
-                    .get_dir_content_filtered_iter()
-                    .filter(|p| p.selected)
+                    .active_selected_entries()
                     .map(crate::DirectoryEntry::to_path_buf)
                     .collect();
 
@@ -2581,6 +2580,13 @@ impl FileDialog {
                 }
             }
         }
+    }
+
+    /// Returns an iterator over the currently selected entries in [`SelectMultiple`] mode.
+    ///
+    /// [`SelectMultiple`]: DialogMode::SelectMultiple
+    pub fn active_selected_entries(&self) -> impl Iterator<Item = &DirectoryEntry> {
+        self.get_dir_content_filtered_iter().filter(|p| p.selected)
     }
 
     /// Submits the file dialog with the specified path and opens the `OverwriteFileModal`

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1000,11 +1000,16 @@ impl FileDialog {
     ///
     /// This is either the currently highlighted entry, or the currently active directory
     /// if nothing is being highlighted.
+    ///
+    /// For the [`DialogMode::SelectMultiple`] counterpart,
+    /// see [`FileDialog::active_selected_entries`].
     pub const fn active_entry(&self) -> Option<&DirectoryEntry> {
         self.selected_item.as_ref()
     }
 
     /// Returns an iterator over the currently selected entries in [`SelectMultiple`] mode.
+    ///
+    /// For the counterpart in single selection modes, see [`FileDialog::active_entry`].
     ///
     /// [`SelectMultiple`]: DialogMode::SelectMultiple
     pub fn active_selected_entries(&self) -> impl Iterator<Item = &DirectoryEntry> {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -998,7 +998,8 @@ impl FileDialog {
 
     /// Returns the currently active directory entry.
     ///
-    /// If no file has been highlighted, it returns the active directory.
+    /// This is either the currently highlighted entry, or the currently active directory
+    /// if nothing is being highlighted.
     pub const fn active_entry(&self) -> Option<&DirectoryEntry> {
         self.selected_item.as_ref()
     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -964,6 +964,13 @@ impl FileDialog {
         }
     }
 
+    /// Returns the currently active directory entry.
+    ///
+    /// If no file has been highlighted, it returns the active directory.
+    pub const fn active_entry(&self) -> Option<&DirectoryEntry> {
+        self.selected_item.as_ref()
+    }
+
     /// Returns the ID of the operation for which the dialog is currently being used.
     ///
     /// See `FileDialog::open` for more information.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -405,7 +405,7 @@ impl FileDialog {
     /// to show the information for.
     ///
     /// This function has no effect if the dialog state is currently not `DialogState::Open`.
-    pub fn update_with_custom_right_panel(
+    pub fn update_with_right_panel_ui(
         &mut self,
         ctx: &egui::Context,
         f: &mut FileDialogUiCallback,


### PR DESCRIPTION
- `active_entry`: Gives access to the `selected_item` field. It allows the user to know what is the currently highlighted file, or currently active directory in absence of a highlighted file.
- `update_with_custom_right_panel`: Does the same thing as `update`, except it also adds a right panel with a custom ui callback to allow the user to show custom information, or open options.