### PR TITLE
Fix heading places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Added `FileDialog::active_selected_entries` and `FileDialog::active_entry` to get information about the current active item/s [#170](https://github.com/fluxxcode/egui-file-dialog/pull/170) (thanks [@crumblingstatue](https://github.com/crumblingstatue)!)
 - Added option to show system files in the hamburger menu [#173](https://github.com/fluxxcode/egui-file-dialog/pull/173) (thanks [@crumblingstatue](https://github.com/crumblingstatue)!)
 
+### 🐛 Bug Fixes
+- Fixed heading `Places` could not be updated using `FileDialogLabels` [#180](https://github.com/fluxxcode/egui-file-dialog/pull/180)
+
 ### 🔧 Changes
 - Use path edit as file to save [#160](https://github.com/fluxxcode/egui-file-dialog/pull/160)
 - Updated sysinfo to version `0.32` [#161](https://github.com/fluxxcode/egui-file-dialog/pull/161)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added option to show system files in the hamburger menu [#173](https://github.com/fluxxcode/egui-file-dialog/pull/173) (thanks [@crumblingstatue](https://github.com/crumblingstatue)!)
 
 ### 🐛 Bug Fixes
-- Fixed heading `Places`not being able to be updated with `FileDialogLabels` [#180](https://github.com/fluxxcode/egui-file-dialog/pull/180)
+- Fixed heading `Places` not being able to be updated with `FileDialogLabels` [#180](https://github.com/fluxxcode/egui-file-dialog/pull/180)
 
 ### 🔧 Changes
 - Use path edit as file to save [#160](https://github.com/fluxxcode/egui-file-dialog/pull/160)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added option to show system files in the hamburger menu [#173](https://github.com/fluxxcode/egui-file-dialog/pull/173) (thanks [@crumblingstatue](https://github.com/crumblingstatue)!)
 
 ### 🐛 Bug Fixes
-- Fixed heading `Places` could not be updated using `FileDialogLabels` [#180](https://github.com/fluxxcode/egui-file-dialog/pull/180)
+- Fixed heading `Places`not being able to be updated with `FileDialogLabels` [#180](https://github.com/fluxxcode/egui-file-dialog/pull/180)
 
 ### 🔧 Changes
 - Use path edit as file to save [#160](https://github.com/fluxxcode/egui-file-dialog/pull/160)

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1566,6 +1566,7 @@ impl FileDialog {
         ui.with_layout(egui::Layout::top_down_justified(egui::Align::LEFT), |ui| {
             // Spacing multiplier used between sections in the left sidebar
             const SPACING_MULTIPLIER: f32 = 4.0;
+
             egui::containers::ScrollArea::vertical()
                 .auto_shrink([false, false])
                 .show(ui, |ui| {
@@ -1687,7 +1688,7 @@ impl FileDialog {
 
         if let Some(dirs) = &user_directories {
             ui.add_space(spacing);
-            ui.label(self.config.labels.heading_places.as_str());
+            ui.label(labels.heading_places.as_str());
 
             if let Some(path) = dirs.home_dir() {
                 self.ui_update_left_panel_entry(ui, &labels.home_dir, path);


### PR DESCRIPTION
Fixed heading places could not be updated using `FileDialogLabels`.

Closes #179 