### PR TITLE
ci: improve workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,16 +16,24 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-  lint-fmt-test:
-    runs-on: ubuntu-latest
+  ci:
+    name: Check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Cargo check --all
-        run: cargo check
+      - name: Build
+        run: cargo build --all --all-features
+
+      - name: Cargo check
+        run: cargo check --all --all-features
 
       - name: Rustfmt
         run: cargo fmt --all -- --check
@@ -35,3 +43,24 @@ jobs:
 
       - name: Test
         run: cargo test --all --all-features
+
+  cargo-machete:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Machete
+        uses: bnjbvr/cargo-machete@main
+
+  typos:
+    # https://github.com/crate-ci/typos
+    # install and run locally: cargo install typos-cli && typos
+    name: typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v4
+
+      - name: Check spelling of entire workspace
+        uses: crate-ci/typos@master

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,6 @@
+[default.extend-words]
+# Don't correct german words
+Ordner = "Ordner"
+Elemente = "Elemente"
+Alle = "Alle"
+Ein = "Ein"

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -122,7 +122,7 @@ pub struct FileDialogKeyBindings {
 }
 
 impl FileDialogKeyBindings {
-    /// Checks wether any of the given keybindings is pressed.
+    /// Checks whether any of the given keybindings is pressed.
     pub fn any_pressed(
         ctx: &egui::Context,
         keybindings: &Vec<KeyBinding>,

--- a/src/data/directory_content.rs
+++ b/src/data/directory_content.rs
@@ -120,10 +120,10 @@ pub enum DirectoryContentState {
     /// If we are currently waiting for the loading process on another thread.
     /// The value is the timestamp when the loading process started.
     Pending(SystemTime),
-    /// If loading the direcotry content finished since the last update call.
+    /// If loading the directory content finished since the last update call.
     /// This is only returned once.
     Finished,
-    /// If loading the directory content was successfull.
+    /// If loading the directory content was successful.
     Success,
     /// If there was an error loading the directory content.
     /// The value contains the error message.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2028,7 +2028,7 @@ impl FileDialog {
         }
     }
 
-    /// Updates the contents of the currenly open directory.
+    /// Updates the contents of the currently open directory.
     /// TODO: Refactor
     fn ui_update_central_panel_content(&mut self, ui: &mut egui::Ui) {
         // Temporarily take ownership of the directory content.


### PR DESCRIPTION
To improve the workflows I did the following:
- Checks and build now running on macOS, Windows and Ubuntu to check for all systems
- Check with `cargo machete` for unused crates
- Check for typos with `typos-cli`
- Add some typos which should be ignored as they are in german
- Fix some typos