### PR TITLE
fix: new folder dialog not updating content

### DIFF
--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2225,15 +2225,10 @@ impl FileDialog {
     }
 
     fn ui_update_create_directory_dialog(&mut self, ui: &mut egui::Ui) -> Option<DirectoryEntry> {
-        if let Some(path) = self
+        self
             .create_directory_dialog
             .update(ui, &self.config)
-            .directory()
-        {
-            Some(self.process_new_folder(&path))
-        } else {
-            None
-        }
+            .directory().map(|path| self.process_new_folder(&path))
     }
 
     /// Selects every item inside the `directory_content` between `item_a` and `item_b`,

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2066,8 +2066,6 @@ impl FileDialog {
                                 should_return = true;
                             }
                         }
-
-                        self.ui_update_create_directory_dialog(ui);
                     },
                 );
             } else {
@@ -2088,7 +2086,9 @@ impl FileDialog {
                         }
                     }
 
-                    self.ui_update_create_directory_dialog(ui);
+                    if let Some(entry) = self.ui_update_create_directory_dialog(ui) {
+                        data.push(entry);
+                    }
                 });
             }
         });
@@ -2224,13 +2224,15 @@ impl FileDialog {
         false
     }
 
-    fn ui_update_create_directory_dialog(&mut self, ui: &mut egui::Ui) {
+    fn ui_update_create_directory_dialog(&mut self, ui: &mut egui::Ui) -> Option<DirectoryEntry> {
         if let Some(path) = self
             .create_directory_dialog
             .update(ui, &self.config)
             .directory()
         {
-            self.process_new_folder(&path);
+            Some(self.process_new_folder(&path))
+        } else {
+            None
         }
     }
 
@@ -2575,12 +2577,14 @@ impl FileDialog {
     }
 
     /// Function that processes a newly created folder.
-    fn process_new_folder(&mut self, created_dir: &Path) {
+    fn process_new_folder(&mut self, created_dir: &Path) -> DirectoryEntry {
         let mut entry = DirectoryEntry::from_path(&self.config, created_dir);
 
         self.directory_content.push(entry.clone());
 
         self.select_item(&mut entry);
+
+        entry
     }
 
     /// Opens a new modal window.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2225,10 +2225,10 @@ impl FileDialog {
     }
 
     fn ui_update_create_directory_dialog(&mut self, ui: &mut egui::Ui) -> Option<DirectoryEntry> {
-        self
-            .create_directory_dialog
+        self.create_directory_dialog
             .update(ui, &self.config)
-            .directory().map(|path| self.process_new_folder(&path))
+            .directory()
+            .map(|path| self.process_new_folder(&path))
     }
 
     /// Selects every item inside the `directory_content` between `item_a` and `item_b`,


### PR DESCRIPTION
Fixed that when creating a new folder using the UI button, the folder was created but the directory contents were not updated.

This was a bug introduced with: https://github.com/fluxxcode/egui-file-dialog/pull/181