### PR TITLE
feat: windows mapped network devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `FileDialog::update_with_right_panel_ui` to add a custom right panel to the file dialog [#170](https://github.com/fluxxcode/egui-file-dialog/pull/170) (thanks [@crumblingstatue](https://github.com/crumblingstatue)!)
 - Added `FileDialog::active_selected_entries` and `FileDialog::active_entry` to get information about the current active item/s [#170](https://github.com/fluxxcode/egui-file-dialog/pull/170) (thanks [@crumblingstatue](https://github.com/crumblingstatue)!)
 - Added option to show system files in the hamburger menu [#173](https://github.com/fluxxcode/egui-file-dialog/pull/173) (thanks [@crumblingstatue](https://github.com/crumblingstatue)!)
+- Support mapped network devies on Windows [#189](https://github.com/fluxxcode/egui-file-dialog/pull/189)
 
 ### 🐛 Bug Fixes
 - Fixed heading `Places` not being able to be updated with `FileDialogLabels` [#180](https://github.com/fluxxcode/egui-file-dialog/pull/180)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added `FileDialog::update_with_right_panel_ui` to add a custom right panel to the file dialog [#170](https://github.com/fluxxcode/egui-file-dialog/pull/170) (thanks [@crumblingstatue](https://github.com/crumblingstatue)!)
 - Added `FileDialog::active_selected_entries` and `FileDialog::active_entry` to get information about the current active item/s [#170](https://github.com/fluxxcode/egui-file-dialog/pull/170) (thanks [@crumblingstatue](https://github.com/crumblingstatue)!)
 - Added option to show system files in the hamburger menu [#173](https://github.com/fluxxcode/egui-file-dialog/pull/173) (thanks [@crumblingstatue](https://github.com/crumblingstatue)!)
-- Support mapped network devies on Windows [#189](https://github.com/fluxxcode/egui-file-dialog/pull/189)
+- Support mapped network devices on Windows [#189](https://github.com/fluxxcode/egui-file-dialog/pull/189)
 
 ### 🐛 Bug Fixes
 - Fixed heading `Places` not being able to be updated with `FileDialogLabels` [#180](https://github.com/fluxxcode/egui-file-dialog/pull/180)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ serde = ["dep:serde"]
 default_fonts = ["egui/default_fonts"]
 
 [lints.rust]
-unsafe_code = "forbid"
+unsafe_code = "warn"
 
 [lints.clippy]
 nursery = { level = "deny", priority = 0 }

--- a/src/data/disks.rs
+++ b/src/data/disks.rs
@@ -18,7 +18,7 @@ impl Disk {
         canonicalize_paths: bool,
     ) -> Self {
         Self {
-            mount_point: Self::canonicalize(&mount_point, canonicalize_paths),
+            mount_point: Self::canonicalize(mount_point, canonicalize_paths),
             display_name: gen_display_name(
                 name.unwrap_or_default(),
                 mount_point.to_str().unwrap_or_default(),

--- a/src/data/disks.rs
+++ b/src/data/disks.rs
@@ -126,16 +126,8 @@ fn load_disks(canonicalize_paths: bool) -> Vec<Disk> {
             let path = PathBuf::from(format!("{}:\\", letter as char));
             let mount_point = canonicalize(&path, canonicalize_paths);
 
-            if !disks
-                .iter()
-                .any(|d| d.mount_point == mount_point)
-            {
-                disks.push(Disk::new(
-                    None,
-                    &path,
-                    false,
-                    canonicalize_paths,
-                ));
+            if !disks.iter().any(|d| d.mount_point == mount_point) {
+                disks.push(Disk::new(None, &path, false, canonicalize_paths));
             }
         }
 

--- a/src/data/disks.rs
+++ b/src/data/disks.rs
@@ -15,7 +15,7 @@ impl Disk {
         name: Option<&str>,
         mount_point: &Path,
         is_removable: bool,
-        canonicalize_paths: bool
+        canonicalize_paths: bool,
     ) -> Self {
         Self {
             mount_point: Self::canonicalize(&mount_point, canonicalize_paths),
@@ -35,7 +35,6 @@ impl Disk {
             disk.is_removable(),
             canonicalize_paths,
         )
-
     }
 
     /// Returns the mount point of the disk
@@ -130,7 +129,10 @@ fn load_disks(canonicalize_paths: bool) -> Vec<Disk> {
         if drives & 1 != 0 {
             let mount_point = format!("{}:\\", letter as char);
 
-            if !disks.iter().any(|d| d.mount_point.to_str().unwrap_or_default() == mount_point) {
+            if !disks
+                .iter()
+                .any(|d| d.mount_point.to_str().unwrap_or_default() == mount_point)
+            {
                 disks.push(Disk::new(
                     None,
                     &PathBuf::from(&mount_point),

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -237,6 +237,9 @@ impl FileDialog {
     pub fn with_config(config: FileDialogConfig) -> Self {
         let mut obj = Self::new();
         *obj.config_mut() = config;
+
+        obj.refresh();
+
         obj
     }
 
@@ -610,8 +613,12 @@ impl FileDialog {
     /// you know what you are doing and have a reason for it.
     /// Disabling canonicalization can lead to unexpected behavior, for example if an
     /// already canonicalized path is then set as the initial directory.
-    pub const fn canonicalize_paths(mut self, canonicalize: bool) -> Self {
+    pub fn canonicalize_paths(mut self, canonicalize: bool) -> Self {
         self.config.canonicalize_paths = canonicalize;
+
+        // Reload data like system disks and user directories with the updated canonicalization.
+        self.refresh();
+
         self
     }
 


### PR DESCRIPTION
This PR adds support for Windows mapped network devices. However, this is more of a temporary implementation until `sysinfo` provides functionality for mapped network devices on Windows.

Ref: #168 