### PR TITLE
show network drives on macOS

### DIFF
--- a/src/data/disks.rs
+++ b/src/data/disks.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "macos")]
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -38,6 +39,7 @@ impl Disk {
         )
     }
 
+    #[cfg(target_os = "macos")]
     pub fn from_path(path: &Path, canonicalize_paths: bool) -> Self {
         let mount_point = canonicalize(path, canonicalize_paths);
 

--- a/src/data/disks.rs
+++ b/src/data/disks.rs
@@ -192,9 +192,11 @@ fn load_disks(canonicalize_paths: bool) -> Vec<Disk> {
         for entry in entries.filter_map(Result::ok) {
             let path = entry.path();
             if seen_mount_points.insert(path.clone()) {
-                if let Ok(metadata) = entry.metadata() {
-                    if metadata.is_dir() {
-                        result.push(Disk::from_path(&path, canonicalize_paths));
+                if let Some(name_osstr) = path.file_name() {
+                    if let Some(name) = name_osstr.to_str() {
+                        if path.is_dir() && !name.starts_with('.') {
+                            result.push(Disk::from_path(&path, canonicalize_paths));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
this addresses https://github.com/fluxxcode/egui-file-dialog/issues/168 for macOS.

It still shows my removable drive twice, for some reason, so this bug is still there. But network drives are available and Macintosh HDD is not shown twice anymore.

<img width="183" alt="Bildschirmfoto 2024-11-18 um 18 29 27" src="https://github.com/user-attachments/assets/4cfdfc88-84c0-4293-b9d3-639649868c14">

Figure: "Space" is a network drive mounted via SMB

EDIT: messed up the rebase on the other PR, so closed it and opened up this one