### PR TITLE
select dropped item

### DIFF
--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -157,7 +157,7 @@ pub struct FileDialog {
     any_focused_last_frame: bool,
 
     /// flag to set if files have been dropped
-    new_file_dropped : bool,
+    new_file_dropped: bool,
 }
 
 /// This tests if file dialog is send and sync.


### PR DESCRIPTION
This adresses #196.

However, in the current state the UI will not scroll to the selected (dropped) item. Even though `self.scroll_to_selection = true;`is set. Any ideas?