### PR TITLE
add workflow to automatically publish a new release to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Upload Rust Crate to crates.io
+
+on:
+  release:
+    types: [ created ]
+
+jobs:
+  crates_io_publish:
+    name: Publish (crates.io)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - run: cargo publish --token ${CRATES_TOKEN}
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
I implemented this on a couple of my own repos, thought I'd propose it here, in case you like it.

With this, a new github-release is also uploaded to crates.io, you don't need to manually run `cargo publish`.

You would have to generate a new API Token on [https://crates.io/me](https://crates.io/me) and add it as a repository secret on github to this repo.