### PR TITLE
rework!: consistent api naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # egui-file-dialog changelog
 
+## Unreleased
+### 🚨 Breaking Changes
+
+- Removed deprecated methods `FileDialog::select_directory`, `FileDialog::select_file`, `FileDialog::select_multiple`, `FileDialog::overwrite_config`, `FileDialog::selected`, `FileDialog::take_selected`, `FileDialog::take_selected_multiple` [#229](https://github.com/fluxxcode/egui-file-dialog/pull/229)
+- Renamed `DialogMode`'s: `SelectFile` -> `PickFile`, `SelectDirectory` -> `PickDirectory`, `SelectMultiple` -> `PickMultiple` [#229](https://github.com/fluxxcode/egui-file-dialog/pull/229)
+- Renamed `DialogState`'s: `Selected` -> `Picked`, `SelectedMultiple` -> `PickedMultiple` [#229](https://github.com/fluxxcode/egui-file-dialog/pull/229)
+- Renamed `active_entry` -> `selected_entry` [#229](https://github.com/fluxxcode/egui-file-dialog/pull/229)
+- Renamed `active_selected_entries` -> `selected_entries` [#229](https://github.com/fluxxcode/egui-file-dialog/pull/229)
+
 ## 2024-12-17 - v0.8.0 - egui update, custom right panel and more
 
 ### 🚨 Breaking Changes

--- a/examples/custom_right_panel.rs
+++ b/examples/custom_right_panel.rs
@@ -45,14 +45,14 @@ impl eframe::App for MyApp {
                         egui::ScrollArea::vertical()
                             .max_height(ui.available_height())
                             .show(ui, |ui| {
-                                for item in dia.active_selected_entries() {
+                                for item in dia.selected_entries() {
                                     ui.small(format!("{item:#?}"));
                                     ui.separator();
                                 }
                             });
                     } else {
                         ui.heading("Active item");
-                        ui.small(format!("{:#?}", dia.active_entry()));
+                        ui.small(format!("{:#?}", dia.selected_entry()));
                     }
                 });
 

--- a/examples/custom_right_panel.rs
+++ b/examples/custom_right_panel.rs
@@ -39,7 +39,7 @@ impl eframe::App for MyApp {
 
             self.file_dialog
                 .update_with_right_panel_ui(ctx, &mut |ui, dia| {
-                    if dia.mode() == DialogMode::SelectMultiple {
+                    if dia.mode() == DialogMode::PickMultiple {
                         ui.heading("Selected items");
                         ui.separator();
                         egui::ScrollArea::vertical()
@@ -57,7 +57,7 @@ impl eframe::App for MyApp {
                 });
 
             match self.file_dialog.mode() {
-                DialogMode::SelectMultiple => {
+                DialogMode::PickMultiple => {
                     if let Some(items) = self.file_dialog.take_picked_multiple() {
                         self.picked_items = Some(items);
                     }

--- a/examples/multiple_actions.rs
+++ b/examples/multiple_actions.rs
@@ -27,13 +27,13 @@ impl eframe::App for MyApp {
             if ui.button("Pick file a").clicked() {
                 let _ = self
                     .file_dialog
-                    .open(DialogMode::SelectFile, true, Some("pick_a"));
+                    .open(DialogMode::PickFile, true, Some("pick_a"));
             }
 
             if ui.button("Pick file b").clicked() {
                 let _ = self
                     .file_dialog
-                    .open(DialogMode::SelectFile, true, Some("pick_b"));
+                    .open(DialogMode::PickFile, true, Some("pick_b"));
             }
 
             ui.label(format!("Pick file a: {:?}", self.picked_file_a));

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -102,10 +102,10 @@ impl eframe::App for MyApp {
 
             if let Some(path) = self.file_dialog.take_picked() {
                 match self.file_dialog.mode() {
-                    DialogMode::SelectDirectory => self.picked_directory = Some(path),
-                    DialogMode::SelectFile => self.picked_file = Some(path),
+                    DialogMode::PickDirectory => self.picked_directory = Some(path),
+                    DialogMode::PickFile => self.picked_file = Some(path),
                     DialogMode::SaveFile => self.saved_file = Some(path),
-                    DialogMode::SelectMultiple => {}
+                    DialogMode::PickMultiple => {}
                 }
             }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -982,7 +982,7 @@ impl FileDialog {
     ///
     /// For the [`DialogMode::SelectMultiple`] counterpart,
     /// see [`FileDialog::active_selected_entries`].
-    pub const fn active_entry(&self) -> Option<&DirectoryEntry> {
+    pub const fn selected_entry(&self) -> Option<&DirectoryEntry> {
         self.selected_item.as_ref()
     }
 
@@ -991,7 +991,7 @@ impl FileDialog {
     /// For the counterpart in single selection modes, see [`FileDialog::active_entry`].
     ///
     /// [`SelectMultiple`]: DialogMode::SelectMultiple
-    pub fn active_selected_entries(&self) -> impl Iterator<Item = &DirectoryEntry> {
+    pub fn selected_entries(&self) -> impl Iterator<Item = &DirectoryEntry> {
         self.get_dir_content_filtered_iter().filter(|p| p.selected)
     }
 
@@ -2749,7 +2749,7 @@ impl FileDialog {
             }
             DialogMode::PickMultiple => {
                 let result: Vec<PathBuf> = self
-                    .active_selected_entries()
+                    .selected_entries()
                     .map(crate::DirectoryEntry::to_path_buf)
                     .collect();
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -62,12 +62,12 @@ pub enum DialogState {
 ///
 /// impl MyApp {
 ///     fn update(&mut self, ctx: &egui::Context, ui: &mut egui::Ui) {
-///         if ui.button("Select a file").clicked() {
-///             self.file_dialog.select_file();
+///         if ui.button("Pick a file").clicked() {
+///             self.file_dialog.pick_file();
 ///         }
 ///
-///         if let Some(path) = self.file_dialog.update(ctx).selected() {
-///             println!("Selected file: {:?}", path);
+///         if let Some(path) = self.file_dialog.update(ctx).picked() {
+///             println!("Picked file: {:?}", path);
 ///         }
 ///     }
 /// }
@@ -275,28 +275,28 @@ impl FileDialog {
     /// struct MyApp {
     ///     file_dialog: FileDialog,
     ///
-    ///     selected_file_a: Option<PathBuf>,
-    ///     selected_file_b: Option<PathBuf>,
+    ///     picked_file_a: Option<PathBuf>,
+    ///     picked_file_b: Option<PathBuf>,
     /// }
     ///
     /// impl MyApp {
     ///     fn update(&mut self, ctx: &egui::Context, ui: &mut egui::Ui) {
-    ///         if ui.button("Select file a").clicked() {
-    ///             let _ = self.file_dialog.open(DialogMode::SelectFile, true, Some("select_a"));
+    ///         if ui.button("Pick file a").clicked() {
+    ///             let _ = self.file_dialog.open(DialogMode::PickFile, true, Some("pick_a"));
     ///         }
     ///
-    ///         if ui.button("Select file b").clicked() {
-    ///             let _ = self.file_dialog.open(DialogMode::SelectFile, true, Some("select_b"));
+    ///         if ui.button("Pick file b").clicked() {
+    ///             let _ = self.file_dialog.open(DialogMode::PickFile, true, Some("pick_b"));
     ///         }
     ///
     ///         self.file_dialog.update(ctx);
     ///
-    ///         if let Some(path) = self.file_dialog.selected() {
-    ///             if self.file_dialog.operation_id() == Some("select_a") {
-    ///                 self.selected_file_a = Some(path.to_path_buf());
+    ///         if let Some(path) = self.file_dialog.picked() {
+    ///             if self.file_dialog.operation_id() == Some("pick_a") {
+    ///                 self.picked_file_a = Some(path.to_path_buf());
     ///             }
-    ///             if self.file_dialog.operation_id() == Some("select_b") {
-    ///                 self.selected_file_b = Some(path.to_path_buf());
+    ///             if self.file_dialog.operation_id() == Some("pick_b") {
+    ///                 self.picked_file_b = Some(path.to_path_buf());
     ///             }
     ///         }
     ///     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1816,9 +1816,7 @@ impl FileDialog {
             }
 
             match &self.mode {
-                DialogMode::PickDirectory
-                | DialogMode::PickFile
-                | DialogMode::PickMultiple => {
+                DialogMode::PickDirectory | DialogMode::PickFile | DialogMode::PickMultiple => {
                     use egui::containers::scroll_area::ScrollBarVisibility;
 
                     let text = self.get_selection_preview_text();
@@ -1943,9 +1941,9 @@ impl FileDialog {
     fn ui_update_action_buttons(&mut self, ui: &mut egui::Ui, button_size: egui::Vec2) {
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
             let label = match &self.mode {
-                DialogMode::PickDirectory
-                | DialogMode::PickFile
-                | DialogMode::PickMultiple => self.config.labels.open_button.as_str(),
+                DialogMode::PickDirectory | DialogMode::PickFile | DialogMode::PickMultiple => {
+                    self.config.labels.open_button.as_str()
+                }
                 DialogMode::SaveFile => self.config.labels.save_button.as_str(),
             };
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -355,22 +355,6 @@ impl FileDialog {
         let _ = self.open(DialogMode::SelectDirectory, false, None);
     }
 
-    /// Shortcut function to open the file dialog to prompt the user to select a directory.
-    /// If used, no files in the directories will be shown to the user.
-    /// Use the `open()` method instead, if you still want to display files to the user.
-    /// This function resets the file dialog. Configuration variables such as
-    /// `initial_directory` are retained.
-    ///
-    /// The function ignores the result of the initial directory loading operation.
-    #[deprecated(
-        since = "0.8.0",
-        note = "renamed to `FileDialog::pick_directory` for more consistent naming. \
-                Will be removed in a future release, most likely 0.9.0."
-    )]
-    pub fn select_directory(&mut self) {
-        self.pick_directory();
-    }
-
     /// Shortcut function to open the file dialog to prompt the user to pick a file.
     /// This function resets the file dialog. Configuration variables such as
     /// `initial_directory` are retained.
@@ -378,20 +362,6 @@ impl FileDialog {
     /// The function ignores the result of the initial directory loading operation.
     pub fn pick_file(&mut self) {
         let _ = self.open(DialogMode::SelectFile, true, None);
-    }
-
-    /// Shortcut function to open the file dialog to prompt the user to select a file.
-    /// This function resets the file dialog. Configuration variables such as
-    /// `initial_directory` are retained.
-    ///
-    /// The function ignores the result of the initial directory loading operation.
-    #[deprecated(
-        since = "0.8.0",
-        note = "renamed to `FileDialog::pick_file` for more consistent naming. \
-                Will be removed in a future release, most likely 0.9.0."
-    )]
-    pub fn select_file(&mut self) {
-        self.pick_file();
     }
 
     /// Shortcut function to open the file dialog to prompt the user to pick multiple
@@ -402,21 +372,6 @@ impl FileDialog {
     /// The function ignores the result of the initial directory loading operation.
     pub fn pick_multiple(&mut self) {
         let _ = self.open(DialogMode::SelectMultiple, true, None);
-    }
-
-    /// Shortcut function to open the file dialog to prompt the user to select multiple
-    /// files and folders.
-    /// This function resets the file dialog. Configuration variables such as `initial_directory`
-    /// are retained.
-    ///
-    /// The function ignores the result of the initial directory loading operation.
-    #[deprecated(
-        since = "0.8.0",
-        note = "renamed to `FileDialog::pick_multiple` for more consistent naming. \
-                Will be removed in a future release, most likely 0.9.0."
-    )]
-    pub fn select_multiple(&mut self) {
-        self.pick_multiple();
     }
 
     /// Shortcut function to open the file dialog to prompt the user to save a file.
@@ -480,72 +435,6 @@ impl FileDialog {
 
     // -------------------------------------------------
     // Setter:
-    /// Overwrites the configuration of the file dialog.
-    ///
-    /// This is useful when you want to configure multiple `FileDialog` objects with the
-    /// same configuration. If you only want to configure a single object,
-    /// it's probably easier to use the setter methods like `FileDialog::initial_directory`
-    /// or `FileDialog::default_pos`.
-    ///
-    /// If you want to create a new `FileDialog` object with a config,
-    /// you probably want to use `FileDialog::with_config`.
-    ///
-    /// NOTE: Any configuration that was set before `FileDialog::overwrite_config`
-    /// will be overwritten! \
-    /// This means, for example, that the following code is invalid:
-    /// ```
-    /// pub use egui_file_dialog::{FileDialog, FileDialogConfig};
-    ///
-    /// fn create_file_dialog() -> FileDialog {
-    ///     FileDialog::new()
-    ///        .title("Hello world")
-    ///         // This will overwrite `.title("Hello world")`!
-    ///        .overwrite_config(FileDialogConfig::default())
-    /// }
-    ///
-    /// ```
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use egui_file_dialog::{FileDialog, FileDialogConfig};
-    ///
-    /// struct MyApp {
-    ///     file_dialog_a: FileDialog,
-    ///     file_dialog_b: FileDialog,
-    /// }
-    ///
-    /// impl MyApp {
-    ///     pub fn new() -> Self {
-    ///         let config = FileDialogConfig {
-    ///             default_size: egui::Vec2::new(500.0, 500.0),
-    ///             resizable: false,
-    ///             movable: false,
-    ///             ..Default::default()
-    ///         };
-    ///
-    ///         Self {
-    ///             file_dialog_a: FileDialog::new()
-    ///                 .overwrite_config(config.clone())
-    ///                 .title("File Dialog A")
-    ///                 .id("fd_a"),
-    ///
-    ///             file_dialog_b: FileDialog::new()
-    ///                 .overwrite_config(config)
-    ///                 .title("File Dialog B")
-    ///                 .id("fd_b"),
-    ///         }
-    ///     }
-    /// }
-    /// ```
-    #[deprecated(
-        since = "0.6.0",
-        note = "use `FileDialog::with_config` and `FileDialog::config_mut` instead"
-    )]
-    pub fn overwrite_config(mut self, config: FileDialogConfig) -> Self {
-        self.config = config;
-        self
-    }
 
     /// Mutably borrow internal `config`.
     pub fn config_mut(&mut self) -> &mut FileDialogConfig {
@@ -1039,19 +928,6 @@ impl FileDialog {
         }
     }
 
-    /// Returns the directory or file that the user selected, or the target file
-    /// if the dialog is in `DialogMode::SaveFile` mode.
-    ///
-    /// None is returned when the user has not yet selected an item.
-    #[deprecated(
-        since = "0.8.0",
-        note = "renamed to `FileDialog::picked` for more consistent naming. \
-                Will be removed in a future release, most likely 0.9.0."
-    )]
-    pub fn selected(&self) -> Option<&Path> {
-        self.picked()
-    }
-
     /// Returns the directory or file that the user picked, or the target file
     /// if the dialog is in `DialogMode::SaveFile` mode.
     /// Unlike `FileDialog::picked`, this method returns the picked path only once and
@@ -1069,21 +945,6 @@ impl FileDialog {
         }
     }
 
-    /// Returns the directory or file that the user selected, or the target file
-    /// if the dialog is in `DialogMode::SaveFile` mode.
-    /// Unlike `FileDialog::selected`, this method returns the selected path only once and
-    /// sets the dialog's state to `DialogState::Closed`.
-    ///
-    /// None is returned when the user has not yet selected an item.
-    #[deprecated(
-        since = "0.8.0",
-        note = "renamed to `FileDialog::take_picked` for more consistent naming. \
-                Will be removed in a future release, most likely 0.9.0."
-    )]
-    pub fn take_selected(&mut self) -> Option<PathBuf> {
-        self.take_picked()
-    }
-
     /// Returns a list of the files and folders the user picked, when the dialog is in
     /// `DialogMode::PickMultiple` mode.
     ///
@@ -1095,19 +956,6 @@ impl FileDialog {
             }
             _ => None,
         }
-    }
-
-    /// Returns a list of the files and folders the user selected, when the dialog is in
-    /// `DialogMode::SelectMultiple` mode.
-    ///
-    /// None is returned when the user has not yet selected an item.
-    #[deprecated(
-        since = "0.8.0",
-        note = "renamed to `FileDialog::picked_multiple` for more consistent naming. \
-                Will be removed in a future release, most likely 0.9.0."
-    )]
-    pub fn selected_multiple(&self) -> Option<Vec<&Path>> {
-        self.picked_multiple()
     }
 
     /// Returns a list of the files and folders the user picked, when the dialog is in
@@ -1125,21 +973,6 @@ impl FileDialog {
             }
             _ => None,
         }
-    }
-
-    /// Returns a list of the files and folders the user selected, when the dialog is in
-    /// `DialogMode::SelectMultiple` mode.
-    /// Unlike `FileDialog::selected_multiple`, this method returns the selected paths only once
-    /// and sets the dialog's state to `DialogState::Closed`.
-    ///
-    /// None is returned when the user has not yet selected an item.
-    #[deprecated(
-        since = "0.8.0",
-        note = "renamed to `FileDialog::take_picked_multiple` for more consistent naming. \
-                Will be removed in a future release, most likely 0.9.0."
-    )]
-    pub fn take_selected_multiple(&mut self) -> Option<Vec<PathBuf>> {
-        self.take_picked_multiple()
     }
 
     /// Returns the currently active directory entry.

--- a/src/information_panel.rs
+++ b/src/information_panel.rs
@@ -270,7 +270,7 @@ impl InformationPanel {
         // Display metadata in a grid format
         let width = file_dialog.config_mut().right_panel_width.unwrap_or(100.0) / 2.0;
 
-        if let Some(item) = file_dialog.active_entry() {
+        if let Some(item) = file_dialog.selected_entry() {
             // load file content and additional metadata if it's a new file
             self.load_meta_data(item);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,14 +53,14 @@
 //!
 //! impl MyApp {
 //!     fn update(&mut self, ctx: &egui::Context, ui: &mut egui::Ui) {
-//!         if ui.button("Select file").clicked() {
-//!             // Open the file dialog to select a file
-//!             self.file_dialog.select_file();
+//!         if ui.button("Pick file").clicked() {
+//!             // Open the file dialog to pick a file
+//!             self.file_dialog.pick_file();
 //!         }
 //!
-//!         // Update the dialog and check if the user selected a file
-//!         if let Some(path) = self.file_dialog.update(ctx).selected() {
-//!             println!("Selected file: {:?}", path);
+//!         // Update the dialog and check if the user picked a file
+//!         if let Some(path) = self.file_dialog.update(ctx).picked() {
+//!             println!("Picked file: {:?}", path);
 //!         }
 //!     }
 //! }


### PR DESCRIPTION
This PR implements the last changes to consistent public API naming. For more information see: #171 and #207.

Changes:
- Removed in #207 deprecated methods: `select_directory`, `select_file`, `select_multiple`, `overwrite_config`, `selected`, `take_selected`, `take_selected_multiple` 
- Renamed `DialogMode`'s: `SelectFile` -> `PickFile`, `SelectDirectory` -> `PickDirectory`, `SelectMultiple` -> `PickMultiple`
- Renamed `DialogState`s: `Selected` -> `Picked`, `SelectedMultiple` -> `PickedMultiple`
- Renamed `active_entry` -> `selected_entry`
- Renamed `active_selected_entries` -> `selected_entries`

Related PR: #207 

Closes #171 