### PR TITLE
Change margins to u8 to follow egui main

### DIFF
--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1348,8 +1348,8 @@ impl FileDialog {
                 1.0,
                 ui.ctx().style().visuals.window_stroke.color,
             ))
-            .inner_margin(egui::Margin::from(4.0))
-            .rounding(egui::Rounding::from(4.0))
+            .inner_margin(egui::Margin::same(4))
+            .rounding(egui::Rounding::same(4))
             .show(ui, |ui| {
                 const EDIT_BUTTON_SIZE: egui::Vec2 = egui::Vec2::new(22.0, 20.0);
 
@@ -1469,8 +1469,8 @@ impl FileDialog {
                 1.0,
                 ui.ctx().style().visuals.window_stroke.color,
             ))
-            .inner_margin(egui::Margin::symmetric(4.0, 4.0))
-            .rounding(egui::Rounding::from(4.0))
+            .inner_margin(egui::Margin::symmetric(4, 4))
+            .rounding(egui::Rounding::same(4))
             .show(ui, |ui| {
                 ui.with_layout(egui::Layout::left_to_right(egui::Align::Min), |ui| {
                     ui.add_space(ui.ctx().style().spacing.item_spacing.y);


### PR DESCRIPTION
Heya! 

Starting with

https://github.com/emilk/egui/commit/249f8bcb9361495fe9245919aa1b16bca424b52b#diff-27a694b8b19044d8b902cbf26c497d371ee974d314ae11413cc10947b05a9f09

in egui upstream, rounding and margins are given in u8 whole points instead of f32.

This breaks in exactly one position - that one inner_margin call in `file_dialog.rs`

This PR fixes this, however this would then stop building on default egui 0.30. Thus this PR includes the same patch line in Cargo.toml that egui_plot is currently using (https://github.com/emilk/egui_plot/blob/80e2199a2e121db288fe6b0099d91c35acc75a7c/Cargo.toml#L43). Those need removal on or before the next egui/egui-file-dialog release.