### PR TITLE
chore: update directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🔧 Changes
 
 - Set up git-lfs to track PNG files and improve repository performance [#218](https://github.com/fluxxcode/egui-file-dialog/pull/218)
+- Updated `directories` dependency from `v0.5.0` to `v0.6.0` [#233](https://github.com/fluxxcode/egui-file-dialog/pull/233/files)
 
 ## 2024-12-17 - v0.8.0 - egui update, custom right panel and more
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 [dependencies]
 egui = { version = "0.30.0", default-features = false }
 # fetch user folders
-directories = "5.0"
+directories = "6.0"
 # canonicalize paths
 dunce = "1.0.5"
 # fetch disks


### PR DESCRIPTION
Updated `directories` dependency from `v0.5.0` to `v0.6.0`