### PR TITLE
fix: canonicalization flag not used during object creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 - Implement file system abstraction so that the file dialog can be used with virtual file systems [#227](https://github.com/fluxxcode/egui-file-dialog/pull/227) (thanks [@Masterchef365](https://github.com/Masterchef365)!)
 
+### 🐛 Bug Fixes
+
+- Fixed canonicalization flag not used during object creation [#237](https://github.com/fluxxcode/egui-file-dialog/pull/237)
+
 ### 🔧 Changes
 
 - Set up git-lfs to track PNG files and improve repository performance [#218](https://github.com/fluxxcode/egui-file-dialog/pull/218)

--- a/src/data/disks.rs
+++ b/src/data/disks.rs
@@ -98,7 +98,7 @@ impl Disks {
     }
 
     /// Creates an empty list of Disks
-    pub fn new_empty() -> Self {
+    pub const fn new_empty() -> Self {
         Self { disks: Vec::new() }
     }
 

--- a/src/data/disks.rs
+++ b/src/data/disks.rs
@@ -99,9 +99,7 @@ impl Disks {
 
     /// Creates an empty list of Disks
     pub fn new_empty() -> Self {
-        Self {
-            disks: Vec::new(),
-        }
+        Self { disks: Vec::new() }
     }
 
     /// Very simple wrapper method of the disks `.iter()` method.

--- a/src/data/disks.rs
+++ b/src/data/disks.rs
@@ -92,7 +92,6 @@ impl Disks {
 
     /// Queries the operating system for disks
     pub fn new_native_disks(canonicalize_paths: bool) -> Self {
-        println!("LOADING_DISKS: {canonicalize_paths}");
         Self {
             disks: load_disks(canonicalize_paths),
         }

--- a/src/data/disks.rs
+++ b/src/data/disks.rs
@@ -92,8 +92,16 @@ impl Disks {
 
     /// Queries the operating system for disks
     pub fn new_native_disks(canonicalize_paths: bool) -> Self {
+        println!("LOADING_DISKS: {canonicalize_paths}");
         Self {
             disks: load_disks(canonicalize_paths),
+        }
+    }
+
+    /// Creates an empty list of Disks
+    pub fn new_empty() -> Self {
+        Self {
+            disks: Vec::new(),
         }
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -564,7 +564,7 @@ impl FileDialog {
     /// you know what you are doing and have a reason for it.
     /// Disabling canonicalization can lead to unexpected behavior, for example if an
     /// already canonicalized path is then set as the initial directory.
-    pub fn canonicalize_paths(mut self, canonicalize: bool) -> Self {
+    pub const fn canonicalize_paths(mut self, canonicalize: bool) -> Self {
         self.config.canonicalize_paths = canonicalize;
         self
     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -204,8 +204,8 @@ impl FileDialog {
 
             window_id: egui::Id::new("file_dialog"),
 
-            user_directories: file_system.user_dirs(true),
-            system_disks: file_system.get_disks(true),
+            user_directories: None,
+            system_disks: Disks::new_empty(),
 
             directory_stack: Vec::new(),
             directory_offset: 0,
@@ -246,9 +246,6 @@ impl FileDialog {
     pub fn with_config(config: FileDialogConfig) -> Self {
         let mut obj = Self::new();
         *obj.config_mut() = config;
-
-        obj.refresh();
-
         obj
     }
 
@@ -320,6 +317,7 @@ impl FileDialog {
         operation_id: Option<&str>,
     ) -> io::Result<()> {
         self.reset();
+        self.refresh();
 
         if mode == DialogMode::PickFile {
             show_files = true;
@@ -568,10 +566,6 @@ impl FileDialog {
     /// already canonicalized path is then set as the initial directory.
     pub fn canonicalize_paths(mut self, canonicalize: bool) -> Self {
         self.config.canonicalize_paths = canonicalize;
-
-        // Reload data like system disks and user directories with the updated canonicalization.
-        self.refresh();
-
         self
     }
 


### PR DESCRIPTION
Fixed canonicalization flag (`FileDialog::canonicalize_paths`) not being used when initializing the file dialog object.
With this PR, the file dialog is now only updated when the `open` method is called and not when the object is initialized.

Ref: #236 