### PR TITLE
feat!: opening mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@
 - Renamed `DialogState`'s: `Selected` -> `Picked`, `SelectedMultiple` -> `PickedMultiple` [#229](https://github.com/fluxxcode/egui-file-dialog/pull/229)
 - Renamed `active_entry` -> `selected_entry` [#229](https://github.com/fluxxcode/egui-file-dialog/pull/229)
 - Renamed `active_selected_entries` -> `selected_entries` [#229](https://github.com/fluxxcode/egui-file-dialog/pull/229)
-- Added `file_system` attribute to `FileDialogConfig` [#227](https://github.com/fluxxcode/egui-file-dialog/pull/227)
+
+#### Breaking changes due to new features and updated configuration
+- Added `file_system` to `FileDialogConfig` [#227](https://github.com/fluxxcode/egui-file-dialog/pull/227)
 - Added `file_system` parameter to `DirectoryEntry::from_path` [#227](https://github.com/fluxxcode/egui-file-dialog/pull/227)
+- Added `opening_mode` to `FileDialogConfig` [#239](https://github.com/fluxxcode/egui-file-dialog/pull/239)
+- Added `last_visited_dir` and `last_picked_dir` to `FileDialogStorage` [#239](https://github.com/fluxxcode/egui-file-dialog/pull/239)
 
 ### ✨ Features
 
 - Implement file system abstraction so that the file dialog can be used with virtual file systems [#227](https://github.com/fluxxcode/egui-file-dialog/pull/227) (thanks [@Masterchef365](https://github.com/Masterchef365)!)
+- Added new configuration option `FileDialog::opening_mode` which allows to further specify which directory is loaded when the file dialog is opened [#239](https://github.com/fluxxcode/egui-file-dialog/pull/239)
 
 ### 🐛 Bug Fixes
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,6 +20,10 @@ pub struct FileDialogStorage {
     pub show_hidden: bool,
     /// If system files should be listed inside the directory view.
     pub show_system_files: bool,
+    /// The last directory the user visited.
+    pub last_visited_dir: Option<PathBuf>,
+    /// The last directory from which the user picked an item.
+    pub last_picked_dir: Option<PathBuf>,
 }
 
 impl Default for FileDialogStorage {
@@ -29,8 +33,22 @@ impl Default for FileDialogStorage {
             pinned_folders: Vec::new(),
             show_hidden: false,
             show_system_files: false,
+            last_visited_dir: None,
+            last_picked_dir: None,
         }
     }
+}
+
+/// Sets which directory is loaded when opening the file dialog.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum OpeningMode {
+    /// The configured initial directory (`FileDialog::initial_directory`) should always be opened.
+    InitialDir,
+    /// The directory most recently visited by the user should be opened regardless of
+    /// whether anything was picked.
+    LastVisitedDir,
+    /// The last directory from which the user picked an item should be opened.
+    LastPickedDir,
 }
 
 /// Contains configuration values of a file dialog.
@@ -77,6 +95,8 @@ pub struct FileDialogConfig {
 
     // ------------------------------------------------------------------------
     // General options:
+    /// Sets which directory is loaded when opening the file dialog.
+    pub opening_mode: OpeningMode,
     /// If the file dialog should be visible as a modal window.
     /// This means that the input outside the window is not registered.
     pub as_modal: bool,
@@ -222,6 +242,7 @@ impl FileDialogConfig {
             labels: FileDialogLabels::default(),
             keybindings: FileDialogKeyBindings::default(),
 
+            opening_mode: OpeningMode::InitialDir,
             as_modal: true,
             modal_overlay_color: egui::Color32::from_rgba_premultiplied(0, 0, 0, 120),
             initial_directory: file_system.current_dir().unwrap_or_default(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -43,7 +43,7 @@ impl Default for FileDialogStorage {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum OpeningMode {
     /// The configured initial directory (`FileDialog::initial_directory`) should always be opened.
-    InitialDir,
+    AlwaysInitialDir,
     /// The directory most recently visited by the user should be opened regardless of
     /// whether anything was picked.
     LastVisitedDir,
@@ -242,7 +242,7 @@ impl FileDialogConfig {
             labels: FileDialogLabels::default(),
             keybindings: FileDialogKeyBindings::default(),
 
-            opening_mode: OpeningMode::InitialDir,
+            opening_mode: OpeningMode::LastPickedDir,
             as_modal: true,
             modal_overlay_color: egui::Color32::from_rgba_premultiplied(0, 0, 0, 120),
             initial_directory: file_system.current_dir().unwrap_or_default(),

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2811,7 +2811,7 @@ impl FileDialog {
     ///   - Attempts to use the parent directory if the path is a file
     fn get_initial_directory(&self) -> PathBuf {
         let path = match self.config.opening_mode {
-            OpeningMode::InitialDir => &self.config.initial_directory,
+            OpeningMode::AlwaysInitialDir => &self.config.initial_directory,
             OpeningMode::LastVisitedDir => self
                 .config
                 .storage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ mod modals;
 
 pub use config::{
     FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, FileDialogStorage, IconFilter,
-    KeyBinding, QuickAccess, QuickAccessPath, OpeningMode,
+    KeyBinding, OpeningMode, QuickAccess, QuickAccessPath,
 };
 pub use data::{DirectoryEntry, Disk, Disks, Metadata, UserDirectories};
 pub use file_dialog::{DialogMode, DialogState, FileDialog};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ mod modals;
 
 pub use config::{
     FileDialogConfig, FileDialogKeyBindings, FileDialogLabels, FileDialogStorage, IconFilter,
-    KeyBinding, QuickAccess, QuickAccessPath,
+    KeyBinding, QuickAccess, QuickAccessPath, OpeningMode,
 };
 pub use data::{DirectoryEntry, Disk, Disks, Metadata, UserDirectories};
 pub use file_dialog::{DialogMode, DialogState, FileDialog};


### PR DESCRIPTION
This PR adds a new configuration option `opening_mode` which allows to further specify which directory is loaded when the file dialog is opened.

Currently the following options are available:
- `OpeningMode::AlwaysInitialDir`: The configured initial directory (`FileDialog::initial_directory`) should always be opened
- `OpeningMode::LastVisitedDir`: The directory most recently visited by the user should be opened regardless of whether anything was picked
- `OpeningMode::LastPickedDir`: The last directory from which the user picked an item should be opened

Which directory was last visited and from which directory the user selected an item is stored in `FileDialogStorage`. This allows the initial directory to be retained even when the application restarts.

Closes #215 