### PR TITLE
refactor: fix file system creation method

### DIFF
--- a/examples/custom_filesystem.rs
+++ b/examples/custom_filesystem.rs
@@ -39,7 +39,7 @@ impl MyApp {
         ];
 
         Self {
-            file_dialog: FileDialog::new().with_file_system(Arc::new(MyFileSystem(root))),
+            file_dialog: FileDialog::with_file_system(Arc::new(MyFileSystem(root))),
             picked_file: None,
         }
     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -234,18 +234,19 @@ impl FileDialog {
         }
     }
 
-    /// Uses the given file system instead of the native file system.
-    #[must_use]
-    pub fn with_file_system(mut self, file_system: Arc<dyn FileSystem + Send + Sync>) -> Self {
-        self.config.initial_directory = file_system.current_dir().unwrap_or_default();
-        self.config.file_system = file_system;
-        self
-    }
-
     /// Creates a new file dialog object and initializes it with the specified configuration.
     pub fn with_config(config: FileDialogConfig) -> Self {
         let mut obj = Self::new();
         *obj.config_mut() = config;
+        obj
+    }
+
+    /// Uses the given file system instead of the native file system.
+    #[must_use]
+    pub fn with_file_system(file_system: Arc<dyn FileSystem + Send + Sync>) -> Self {
+        let mut obj = Self::new();
+        obj.config.initial_directory = file_system.current_dir().unwrap_or_default();
+        obj.config.file_system = file_system;
         obj
     }
 

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -26,7 +26,7 @@ use crate::data::{Disks, Metadata, UserDirectories};
 ///     fn current_dir(&self) -> io::Result<PathBuf> { Ok("/".into()) }
 /// }
 ///
-/// let dialog = FileDialog::new().with_file_system(std::sync::Arc::new(MyFileSystem));
+/// let dialog = FileDialog::with_file_system(std::sync::Arc::new(MyFileSystem));
 ///
 /// /* Use the file dialog as usual */
 /// ```


### PR DESCRIPTION
Fixed issue on my part. When I reviewed #227  I assumed that `FileSystem::with_file_system` should be a builder method. However, because of the initial directory, this has to be a creation function.

This is not a breaking change since the latest version does not yet include the file system abstraction.