### PR TITLE
refactor!: remove result from open method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Renamed `DialogState`'s: `Selected` -> `Picked`, `SelectedMultiple` -> `PickedMultiple` [#229](https://github.com/fluxxcode/egui-file-dialog/pull/229)
 - Renamed `active_entry` -> `selected_entry` [#229](https://github.com/fluxxcode/egui-file-dialog/pull/229)
 - Renamed `active_selected_entries` -> `selected_entries` [#229](https://github.com/fluxxcode/egui-file-dialog/pull/229)
+- Removed result from `FileDialog::open` [#242](https://github.com/fluxxcode/egui-file-dialog/pull/242)
 
 #### Breaking changes due to new features and updated configuration
 - Added `file_system` to `FileDialogConfig` [#227](https://github.com/fluxxcode/egui-file-dialog/pull/227)

--- a/examples/multiple_actions.rs
+++ b/examples/multiple_actions.rs
@@ -25,14 +25,12 @@ impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             if ui.button("Pick file a").clicked() {
-                let _ = self
-                    .file_dialog
+                self.file_dialog
                     .open(DialogMode::PickFile, true, Some("pick_a"));
             }
 
             if ui.button("Pick file b").clicked() {
-                let _ = self
-                    .file_dialog
+                self.file_dialog
                     .open(DialogMode::PickFile, true, Some("pick_b"));
             }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -315,7 +315,7 @@ impl FileDialog {
         mode: DialogMode,
         mut show_files: bool,
         operation_id: Option<&str>,
-    ) -> io::Result<()> {
+    ) {
         self.reset();
         self.refresh();
 
@@ -348,9 +348,6 @@ impl FileDialog {
             .map_or_else(|| egui::Id::new(self.get_window_title()), |id| id);
 
         self.load_directory(&self.get_initial_directory());
-
-        // TODO: Dont return a result from this method
-        Ok(())
     }
 
     /// Shortcut function to open the file dialog to prompt the user to pick a directory.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -10,7 +10,6 @@ use crate::modals::{FileDialogModal, ModalAction, ModalState, OverwriteFileModal
 use crate::{FileSystem, NativeFileSystem};
 use egui::text::{CCursor, CCursorRange};
 use std::fmt::Debug;
-use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -353,7 +352,7 @@ impl FileDialog {
     ///
     /// The function ignores the result of the initial directory loading operation.
     pub fn pick_directory(&mut self) {
-        let _ = self.open(DialogMode::PickDirectory, false, None);
+        self.open(DialogMode::PickDirectory, false, None);
     }
 
     /// Shortcut function to open the file dialog to prompt the user to pick a file.
@@ -362,7 +361,7 @@ impl FileDialog {
     ///
     /// The function ignores the result of the initial directory loading operation.
     pub fn pick_file(&mut self) {
-        let _ = self.open(DialogMode::PickFile, true, None);
+        self.open(DialogMode::PickFile, true, None);
     }
 
     /// Shortcut function to open the file dialog to prompt the user to pick multiple
@@ -372,7 +371,7 @@ impl FileDialog {
     ///
     /// The function ignores the result of the initial directory loading operation.
     pub fn pick_multiple(&mut self) {
-        let _ = self.open(DialogMode::PickMultiple, true, None);
+        self.open(DialogMode::PickMultiple, true, None);
     }
 
     /// Shortcut function to open the file dialog to prompt the user to save a file.
@@ -381,7 +380,7 @@ impl FileDialog {
     ///
     /// The function ignores the result of the initial directory loading operation.
     pub fn save_file(&mut self) {
-        let _ = self.open(DialogMode::SaveFile, true, None);
+        self.open(DialogMode::SaveFile, true, None);
     }
 
     /// The main update method that should be called every frame if the dialog is to be visible.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -310,12 +310,7 @@ impl FileDialog {
     ///     }
     /// }
     /// ```
-    pub fn open(
-        &mut self,
-        mode: DialogMode,
-        mut show_files: bool,
-        operation_id: Option<&str>,
-    ) {
+    pub fn open(&mut self, mode: DialogMode, mut show_files: bool, operation_id: Option<&str>) {
         self.reset();
         self.refresh();
 


### PR DESCRIPTION
Removed result from `FileDialog::open`. Since #177 we don't know the result of loading the initial directory because it is done asynchronously