### PR TITLE
feat: working directory shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### ✨ Features
+
+- Added shortcut to open current working directory to hamburger menu [#246](https://github.com/fluxxcode/egui-file-dialog/pull/246)
+
 ### 🔧 Changes
 
 - Excluded media files from package to reduce size [#244](https://github.com/fluxxcode/egui-file-dialog/pull/244)

--- a/src/config/labels.rs
+++ b/src/config/labels.rs
@@ -131,7 +131,7 @@ impl Default for FileDialogLabels {
             overwrite: "Overwrite".to_string(),
 
             reload: "⟲  Reload".to_string(),
-            working_directory: "↗  Open working directory".to_string(),
+            working_directory: "↗  Go to working directory".to_string(),
             show_hidden: " Show hidden".to_string(),
             show_system_files: " Show system files".to_string(),
 

--- a/src/config/labels.rs
+++ b/src/config/labels.rs
@@ -41,6 +41,8 @@ pub struct FileDialogLabels {
     // Top panel:
     /// Text used for the option to reload the file dialog.
     pub reload: String,
+    /// Text used for the option to open the working directory.
+    pub working_directory: String,
     /// Text used for the option to show or hide hidden files and folders.
     pub show_hidden: String,
     /// Text used for the option to show or hide system files.
@@ -129,6 +131,7 @@ impl Default for FileDialogLabels {
             overwrite: "Overwrite".to_string(),
 
             reload: "⟲  Reload".to_string(),
+            working_directory: "🔧  Open working directory".to_string(),
             show_hidden: " Show hidden".to_string(),
             show_system_files: " Show system files".to_string(),
 

--- a/src/config/labels.rs
+++ b/src/config/labels.rs
@@ -131,7 +131,7 @@ impl Default for FileDialogLabels {
             overwrite: "Overwrite".to_string(),
 
             reload: "⟲  Reload".to_string(),
-            working_directory: "🔧  Open working directory".to_string(),
+            working_directory: "↗  Open working directory".to_string(),
             show_hidden: " Show hidden".to_string(),
             show_system_files: " Show system files".to_string(),
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -204,6 +204,8 @@ pub struct FileDialogConfig {
     pub show_menu_button: bool,
     /// If the reload button inside the top panel menu should be visible.
     pub show_reload_button: bool,
+    /// If the working directory shortcut in the hamburger menu should be visible.
+    pub show_working_directory_button: bool,
     /// If the show hidden files and folders option inside the top panel menu should be visible.
     pub show_hidden_option: bool,
     /// If the show system files option inside the top panel menu should be visible.
@@ -294,6 +296,7 @@ impl FileDialogConfig {
             show_path_edit_button: true,
             show_menu_button: true,
             show_reload_button: true,
+            show_working_directory_button: true,
             show_hidden_option: true,
             show_system_files_option: true,
             show_search: true,

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1457,6 +1457,8 @@ impl FileDialog {
 
     /// Updates the hamburger menu containing different options.
     fn ui_update_hamburger_menu(&mut self, ui: &mut egui::Ui) {
+        const SEPARATOR_SPACING: f32 = 2.0;
+
         if self.config.show_reload_button && ui.button(&self.config.labels.reload).clicked() {
             self.refresh();
             ui.close_menu();
@@ -1475,7 +1477,9 @@ impl FileDialog {
         if (self.config.show_reload_button || self.config.show_working_directory_button)
             && (self.config.show_hidden_option || self.config.show_system_files_option)
         {
+            ui.add_space(SEPARATOR_SPACING);
             ui.separator();
+            ui.add_space(SEPARATOR_SPACING);
         }
 
         if self.config.show_hidden_option

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1253,43 +1253,15 @@ impl FileDialog {
             if self.config.show_menu_button
                 && (self.config.show_reload_button
                     || self.config.show_hidden_option
-                    || self.config.show_system_files_option)
+                    || self.config.show_system_files_option
+                    || self.config.show_working_directory)
             {
                 ui.allocate_ui_with_layout(
                     BUTTON_SIZE,
                     egui::Layout::centered_and_justified(egui::Direction::LeftToRight),
                     |ui| {
                         ui.menu_button("☰", |ui| {
-                            if self.config.show_reload_button
-                                && ui.button(&self.config.labels.reload).clicked()
-                            {
-                                self.refresh();
-                                ui.close_menu();
-                            }
-
-                            if self.config.show_hidden_option
-                                && ui
-                                    .checkbox(
-                                        &mut self.config.storage.show_hidden,
-                                        &self.config.labels.show_hidden,
-                                    )
-                                    .clicked()
-                            {
-                                self.refresh();
-                                ui.close_menu();
-                            }
-
-                            if self.config.show_system_files_option
-                                && ui
-                                    .checkbox(
-                                        &mut self.config.storage.show_system_files,
-                                        &self.config.labels.show_system_files,
-                                    )
-                                    .clicked()
-                            {
-                                self.refresh();
-                                ui.close_menu();
-                            }
+                            self.ui_update_hamburger_menu(ui);
                         });
                     },
                 );
@@ -1466,6 +1438,40 @@ impl FileDialog {
 
         if !response.has_focus() && !btn_response.contains_pointer() {
             self.path_edit_visible = false;
+        }
+    }
+
+    /// Updates the hamburger menu containing different options.
+    fn ui_update_hamburger_menu(&mut self, ui: &mut egui::Ui) {
+        if self.config.show_reload_button
+            && ui.button(&self.config.labels.reload).clicked()
+        {
+            self.refresh();
+            ui.close_menu();
+        }
+
+        if self.config.show_hidden_option
+            && ui
+                .checkbox(
+                    &mut self.config.storage.show_hidden,
+                    &self.config.labels.show_hidden,
+                )
+                .clicked()
+        {
+            self.refresh();
+            ui.close_menu();
+        }
+
+        if self.config.show_system_files_option
+            && ui
+                .checkbox(
+                    &mut self.config.storage.show_system_files,
+                    &self.config.labels.show_system_files,
+                )
+                .clicked()
+        {
+            self.refresh();
+            ui.close_menu();
         }
     }
 
@@ -1669,7 +1675,6 @@ impl FileDialog {
             if let Some(path) = dirs.home_dir() {
                 self.ui_update_left_panel_entry(ui, &labels.home_dir, path);
             }
-
             if let Some(path) = dirs.desktop_dir() {
                 self.ui_update_left_panel_entry(ui, &labels.desktop_dir, path);
             }


### PR DESCRIPTION
This PR adds a new shortcut button to the hamburger menu, allowing to quickly open the current working directory returned by `std::env::current_dir`. The button can be disabled using `FileDialog::show_working_directory_button`.