### PR TITLE
feat: implement extension filter when saving a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### ✨ Features
 
 - Added shortcut to open current working directory to hamburger menu [#246](https://github.com/fluxxcode/egui-file-dialog/pull/246)
-- Added file extensions and filters when saving a file using `FileDialog::add_save_extension` or `FileDialogConfig::add_save_extension` [#248](https://github.com/fluxxcode/egui-file-dialog/pull/248)
+- Added file extensions and filters when saving a file using `FileDialog::add_save_extension`, `FileDialogConfig::add_save_extension` and `FileDialog::default_save_extension` [#248](https://github.com/fluxxcode/egui-file-dialog/pull/248)
 
 ### 🔧 Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 - Excluded media files from package to reduce size [#244](https://github.com/fluxxcode/egui-file-dialog/pull/244)
 - Fixed triggering branches in CI [#247](https://github.com/fluxxcode/egui-file-dialog/pull/247)
-- Changed default file name from an emptry string to `Untitled` [#248](https://github.com/fluxxcode/egui-file-dialog/pull/248)
+- Changed default file name from an empty string to `Untitled` [#248](https://github.com/fluxxcode/egui-file-dialog/pull/248)
 
 ## 2025-02-04 - v0.9.0 - egui update, virtual file system and more
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Excluded media files from package to reduce size [#244](https://github.com/fluxxcode/egui-file-dialog/pull/244)
 - Fixed triggering branches in CI [#247](https://github.com/fluxxcode/egui-file-dialog/pull/247)
+- Changed default file name from an emptry string to `Untitled` [#248](https://github.com/fluxxcode/egui-file-dialog/pull/248)
 
 ## 2025-02-04 - v0.9.0 - egui update, virtual file system and more
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## Unreleased
 
+### 🚨 Breaking Changes
+
+#### Breaking changes due to new features and updated configuration
+- Added `save_extensions` and `default_save_extension` to `FileDialogConfig` [#248](https://github.com/fluxxcode/egui-file-dialog/pull/248)
+- Added `save_extension_any` to `FileDialogLabels` [#248](https://github.com/fluxxcode/egui-file-dialog/pull/248)
+
 ### ✨ Features
 
 - Added shortcut to open current working directory to hamburger menu [#246](https://github.com/fluxxcode/egui-file-dialog/pull/246)
+- Added file extensions and filters when saving a file using `FileDialog::add_save_extension` or `FileDialogConfig::add_save_extension` [#248](https://github.com/fluxxcode/egui-file-dialog/pull/248)
 
 ### 🔧 Changes
 

--- a/examples/multilingual.rs
+++ b/examples/multilingual.rs
@@ -45,6 +45,7 @@ fn get_labels_german() -> FileDialogLabels {
         selected_items: "Ausgewählte Elemente:".to_string(),
         file_name: "Dateiname:".to_string(),
         file_filter_all_files: "Alle Dateien".to_string(),
+        save_extension_any: "Alle".to_string(),
 
         open_button: "🗀  Öffnen".to_string(),
         save_button: "📥  Speichern".to_string(),

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -32,9 +32,9 @@ impl MyApp {
                 "TOML files",
                 Arc::new(|p| p.extension().unwrap_or_default() == "toml"),
             )
-            .add_save_extension("PNG file", "png", true)
-            .add_save_extension("RS file", "rs", true)
-            .add_save_extension("TOML file", "toml", false)
+            .add_save_extension("PNG file", "png")
+            .add_save_extension("RS file", "rs")
+            .add_save_extension("TOML file", "toml")
             .default_save_extension("TOML file")
             .id("egui_file_dialog");
 

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -32,6 +32,9 @@ impl MyApp {
                 "TOML files",
                 Arc::new(|p| p.extension().unwrap_or_default() == "toml"),
             )
+            .add_save_extension("PNG file", "png", true)
+            .add_save_extension("RS file", "rs", true)
+            .add_save_extension("TOML file", "toml", false)
             .id("egui_file_dialog");
 
         if let Some(storage) = cc.storage {

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -32,10 +32,10 @@ impl MyApp {
                 "TOML files",
                 Arc::new(|p| p.extension().unwrap_or_default() == "toml"),
             )
-            .add_save_extension("PNG file", "png")
-            .add_save_extension("RS file", "rs")
-            .add_save_extension("TOML file", "toml")
-            .default_save_extension("TOML file")
+            .add_save_extension("Picture", "png")
+            .add_save_extension("Rust Source File", "rs")
+            .add_save_extension("Configuration File", "toml")
+            .default_save_extension("Picture")
             .id("egui_file_dialog");
 
         if let Some(storage) = cc.storage {

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -35,6 +35,7 @@ impl MyApp {
             .add_save_extension("PNG file", "png", true)
             .add_save_extension("RS file", "rs", true)
             .add_save_extension("TOML file", "toml", false)
+            .default_save_extension("TOML file")
             .id("egui_file_dialog");
 
         if let Some(storage) = cc.storage {

--- a/src/config/labels.rs
+++ b/src/config/labels.rs
@@ -93,6 +93,8 @@ pub struct FileDialogLabels {
     pub file_name: String,
     /// Text displayed in the file filter dropdown for the "All Files" option.
     pub file_filter_all_files: String,
+    /// Text displayed in the save extension dropdown for the "Any" option.
+    pub save_extension_any: String,
 
     /// Button text to open the selected item.
     pub open_button: String,
@@ -156,6 +158,7 @@ impl Default for FileDialogLabels {
             selected_items: "Selected items:".to_string(),
             file_name: "File name:".to_string(),
             file_filter_all_files: "All Files".to_string(),
+            save_extension_any: "Any".to_string(),
 
             open_button: "🗀  Open".to_string(),
             save_button: "📥  Save".to_string(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -364,7 +364,7 @@ impl FileDialogConfig {
 
         self.file_filters.push(FileFilter {
             id,
-            name: name.to_string(),
+            name: name.to_owned(),
             filter,
         });
 
@@ -381,6 +381,8 @@ impl FileDialogConfig {
     ///
     /// * `name` - Display name of the save extension.
     /// * `file_extension` - The file extension to use.
+    /// * `display_extension` - If the extension should be displayed next to its name.
+    ///    For example: "PNG Files (png)" when enabled or "PNG Files" when disabled.
     ///
     /// # Examples
     ///
@@ -389,10 +391,15 @@ impl FileDialogConfig {
     /// use egui_file_dialog::FileDialogConfig;
     ///
     /// let config = FileDialogConfig::default()
-    ///     .add_save_extension("PNG files", "png"))
-    ///     .add_save_extension("JPG files", "jpg"))
+    ///     .add_save_extension("PNG files", "png", true)
+    ///     .add_save_extension("JPG files", "jpg", true)
     /// ```
-    pub fn add_save_extension(mut self, name: &str, file_extension: String) -> Self {
+    pub fn add_save_extension(
+        mut self,
+        name: &str,
+        file_extension: &str,
+        display_extension: bool,
+    ) -> Self {
         let id = egui::Id::new(name);
 
         // Replace extension when an extension with the same name already exists.
@@ -403,8 +410,9 @@ impl FileDialogConfig {
 
         self.save_extensions.push(SaveExtension {
             id,
-            name: name.to_string(),
-            file_extension,
+            name: name.to_owned(),
+            file_extension: file_extension.to_owned(),
+            display_extension,
         });
 
         self
@@ -500,6 +508,18 @@ pub struct SaveExtension {
     pub name: String,
     /// The file extension to use.
     pub file_extension: String,
+    /// If the file extension should be displayed to the user next to the extension name.
+    pub display_extension: bool,
+}
+
+impl SaveExtension {
+    pub fn to_string(&self) -> String {
+        if self.display_extension {
+            format!("{} (.{})", &self.name, &self.file_extension)
+        } else {
+            self.name.clone()
+        }
+    }
 }
 
 /// Sets a specific icon for directory entries.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -391,7 +391,7 @@ impl FileDialogConfig {
     ///
     /// let config = FileDialogConfig::default()
     ///     .add_save_extension("PNG files", "png")
-    ///     .add_save_extension("JPG files", "jpg")
+    ///     .add_save_extension("JPG files", "jpg");
     /// ```
     pub fn add_save_extension(mut self, name: &str, file_extension: &str) -> Self {
         let id = egui::Id::new(name);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -106,7 +106,7 @@ pub struct FileDialogConfig {
     /// The first directory that will be opened when the dialog opens.
     pub initial_directory: PathBuf,
     /// The default filename when opening the dialog in `DialogMode::SaveFile` mode.
-    pub default_file_name: Option<String>,
+    pub default_file_name: String,
     /// If the user is allowed to select an already existing file when the dialog is
     /// in `DialogMode::SaveFile` mode.
     pub allow_file_overwrite: bool,
@@ -253,7 +253,7 @@ impl FileDialogConfig {
             as_modal: true,
             modal_overlay_color: egui::Color32::from_rgba_premultiplied(0, 0, 0, 120),
             initial_directory: file_system.current_dir().unwrap_or_default(),
-            default_file_name: None,
+            default_file_name: String::from("Untitled"),
             allow_file_overwrite: true,
             allow_path_edit_to_save_file_without_extension: false,
             directory_separator: String::from(">"),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -381,8 +381,6 @@ impl FileDialogConfig {
     ///
     /// * `name` - Display name of the save extension.
     /// * `file_extension` - The file extension to use.
-    /// * `display_extension` - If the extension should be displayed next to its name.
-    ///    For example: "PNG Files (png)" when enabled or "PNG Files" when disabled.
     ///
     /// # Examples
     ///
@@ -391,14 +389,13 @@ impl FileDialogConfig {
     /// use egui_file_dialog::FileDialogConfig;
     ///
     /// let config = FileDialogConfig::default()
-    ///     .add_save_extension("PNG files", "png", true)
-    ///     .add_save_extension("JPG files", "jpg", true)
+    ///     .add_save_extension("PNG files", "png")
+    ///     .add_save_extension("JPG files", "jpg")
     /// ```
     pub fn add_save_extension(
         mut self,
         name: &str,
         file_extension: &str,
-        display_extension: bool,
     ) -> Self {
         let id = egui::Id::new(name);
 
@@ -412,7 +409,6 @@ impl FileDialogConfig {
             id,
             name: name.to_owned(),
             file_extension: file_extension.to_owned(),
-            display_extension,
         });
 
         self
@@ -508,17 +504,11 @@ pub struct SaveExtension {
     pub name: String,
     /// The file extension to use.
     pub file_extension: String,
-    /// If the file extension should be displayed to the user next to the extension name.
-    pub display_extension: bool,
 }
 
 impl SaveExtension {
     pub fn to_string(&self) -> String {
-        if self.display_extension {
-            format!("{} (.{})", &self.name, &self.file_extension)
-        } else {
-            self.name.clone()
-        }
+        format!("{} (.{})", &self.name, &self.file_extension)
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -149,6 +149,10 @@ pub struct FileDialogConfig {
     pub file_filters: Vec<FileFilter>,
     /// Name of the file filter to be selected by default.
     pub default_file_filter: Option<String>,
+    /// File extensions presented to the user in a dropdown when saving a file.
+    pub save_extensions: Vec<SaveExtension>,
+    /// Name of the file extension selected by default.
+    pub default_save_extension: Option<String>,
     /// Sets custom icons for different files or folders.
     /// Use `FileDialogConfig::set_file_icon` to add a new icon to this list.
     pub file_icon_filters: Vec<IconFilter>,
@@ -271,6 +275,8 @@ impl FileDialogConfig {
 
             file_filters: Vec::new(),
             default_file_filter: None,
+            save_extensions: Vec::new(),
+            default_save_extension: None,
             file_icon_filters: Vec::new(),
 
             quick_accesses: Vec::new(),
@@ -350,6 +356,7 @@ impl FileDialogConfig {
     pub fn add_file_filter(mut self, name: &str, filter: Filter<Path>) -> Self {
         let id = egui::Id::new(name);
 
+        // Replace filter if a filter with the same name already exists.
         if let Some(item) = self.file_filters.iter_mut().find(|p| p.id == id) {
             item.filter = filter.clone();
             return self;
@@ -359,6 +366,45 @@ impl FileDialogConfig {
             id,
             name: name.to_string(),
             filter,
+        });
+
+        self
+    }
+
+    /// Adds a new file extension that the user can select in a dropdown widget when
+    /// saving a file.
+    ///
+    /// NOTE: The name must be unique. If an extension with the same name already exists,
+    ///       it will be overwritten.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Display name of the save extension.
+    /// * `file_extension` - The file extension to use.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use egui_file_dialog::FileDialogConfig;
+    ///
+    /// let config = FileDialogConfig::default()
+    ///     .add_save_extension("PNG files", "png"))
+    ///     .add_save_extension("JPG files", "jpg"))
+    /// ```
+    pub fn add_save_extension(mut self, name: &str, file_extension: String) -> Self {
+        let id = egui::Id::new(name);
+
+        // Replace extension when an extension with the same name already exists.
+        if let Some(item) = self.save_extensions.iter_mut().find(|p| p.id == id) {
+            item.file_extension = file_extension.to_owned();
+            return self;
+        }
+
+        self.save_extensions.push(SaveExtension {
+            id,
+            name: name.to_string(),
+            file_extension,
         });
 
         self
@@ -443,6 +489,17 @@ impl std::fmt::Debug for FileFilter {
             .field("name", &self.name)
             .finish()
     }
+}
+
+/// Defines a specific file extension that the user can select when saving a file.
+#[derive(Clone, Debug)]
+pub struct SaveExtension {
+    /// The ID of the file filter, used internally for identification.
+    pub id: egui::Id,
+    /// The display name of the file filter.
+    pub name: String,
+    /// The file extension to use.
+    pub file_extension: String,
 }
 
 /// Sets a specific icon for directory entries.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -105,7 +105,7 @@ pub struct FileDialogConfig {
     /// The first directory that will be opened when the dialog opens.
     pub initial_directory: PathBuf,
     /// The default filename when opening the dialog in `DialogMode::SaveFile` mode.
-    pub default_file_name: String,
+    pub default_file_name: Option<String>,
     /// If the user is allowed to select an already existing file when the dialog is
     /// in `DialogMode::SaveFile` mode.
     pub allow_file_overwrite: bool,
@@ -252,7 +252,7 @@ impl FileDialogConfig {
             as_modal: true,
             modal_overlay_color: egui::Color32::from_rgba_premultiplied(0, 0, 0, 120),
             initial_directory: file_system.current_dir().unwrap_or_default(),
-            default_file_name: String::new(),
+            default_file_name: None,
             allow_file_overwrite: true,
             allow_path_edit_to_save_file_without_extension: false,
             directory_separator: String::from(">"),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,9 +4,9 @@ pub use labels::FileDialogLabels;
 mod keybindings;
 pub use keybindings::{FileDialogKeyBindings, KeyBinding};
 
+use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::fmt::Display;
 
 use crate::data::DirectoryEntry;
 use crate::{FileSystem, NativeFileSystem};

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,7 @@ pub use keybindings::{FileDialogKeyBindings, KeyBinding};
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::fmt::Display;
 
 use crate::data::DirectoryEntry;
 use crate::{FileSystem, NativeFileSystem};
@@ -397,7 +398,7 @@ impl FileDialogConfig {
 
         // Replace extension when an extension with the same name already exists.
         if let Some(item) = self.save_extensions.iter_mut().find(|p| p.id == id) {
-            item.file_extension = file_extension.to_owned();
+            file_extension.clone_into(&mut item.file_extension);
             return self;
         }
 
@@ -502,9 +503,9 @@ pub struct SaveExtension {
     pub file_extension: String,
 }
 
-impl SaveExtension {
-    pub fn to_string(&self) -> String {
-        format!("{} (.{})", &self.name, &self.file_extension)
+impl Display for SaveExtension {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format!("{} (.{})", &self.name, &self.file_extension))
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -392,11 +392,7 @@ impl FileDialogConfig {
     ///     .add_save_extension("PNG files", "png")
     ///     .add_save_extension("JPG files", "jpg")
     /// ```
-    pub fn add_save_extension(
-        mut self,
-        name: &str,
-        file_extension: &str,
-    ) -> Self {
+    pub fn add_save_extension(mut self, name: &str, file_extension: &str) -> Self {
         let id = egui::Id::new(name);
 
         // Replace extension when an extension with the same name already exists.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1912,7 +1912,7 @@ impl FileDialog {
                         });
                 }
                 DialogMode::SaveFile => {
-                    let mut output =  egui::TextEdit::singleline(&mut self.file_name_input)
+                    let mut output = egui::TextEdit::singleline(&mut self.file_name_input)
                         .cursor_at_end(false)
                         .margin(egui::Margin::symmetric(4, 3))
                         .desired_width(scroll_bar_width - item_spacing.x)
@@ -1926,12 +1926,12 @@ impl FileDialog {
                         self.file_name_input_request_focus = false;
                     }
 
-
                     if output.response.changed() {
                         self.file_name_input_error = self.validate_file_name_input();
                     }
 
-                    if output.response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                    if output.response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter))
+                    {
                         self.submit();
                     }
                 }
@@ -1965,15 +1965,9 @@ impl FileDialog {
     fn highlight_file_name_input(&self, output: &mut egui::text_edit::TextEditOutput) {
         if let Some(pos) = self.file_name_input.rfind('.') {
             let range = if pos == 0 {
-                CCursorRange::two(
-                    CCursor::new(0),
-                    CCursor::new(0),
-                )
+                CCursorRange::two(CCursor::new(0), CCursor::new(0))
             } else {
-                CCursorRange::two(
-                    CCursor::new(0),
-                    CCursor::new(pos),
-                )
+                CCursorRange::two(CCursor::new(0), CCursor::new(pos))
             };
 
             output.state.cursor.set_char_range(Some(range));

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -328,6 +328,8 @@ impl FileDialog {
         self.set_default_save_extension();
 
         if mode == DialogMode::SaveFile {
+            self.file_name_input_request_focus = true;
+
             if let Some(name) = &self.config.default_file_name {
                 self.file_name_input.clone_from(name);
             }
@@ -1920,6 +1922,7 @@ impl FileDialog {
                 DialogMode::SaveFile => {
                     let response = ui.add(
                         egui::TextEdit::singleline(&mut self.file_name_input)
+                            .cursor_at_end(false)
                             .desired_width(scroll_bar_width - item_spacing.x),
                     );
 
@@ -2059,6 +2062,7 @@ impl FileDialog {
             });
 
         if let Some(i) = select_extension {
+            self.file_name_input_request_focus = true;
             self.select_save_extension(i);
         }
     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2809,14 +2809,25 @@ impl FileDialog {
             for extension in &self.config.save_extensions {
                 if extension.name == name.as_str() {
                     self.selected_save_extension = Some(extension.id);
+                    self.file_name_input = format!(".{}", extension.file_extension);
                 }
             }
         }
     }
 
-    /// Selects the given save extension and applies the appropriate filters.
+    /// Selects the given save extension.
     fn select_save_extension(&mut self, extension: Option<SaveExtension>) {
-        self.selected_save_extension = extension.and_then(|e| Some(e.id));
+        if let Some(ex) = extension {
+            self.selected_save_extension =  Some(ex.id);
+
+            let mut p = PathBuf::from(&self.file_name_input);
+            if p.set_extension(&ex.file_extension) {
+                self.file_name_input = p.to_string_lossy().into_owned();
+            } else {
+                self.file_name_input = format!(".{}", ex.file_extension);
+            }
+        }
+
         self.selected_item = None;
         self.refresh();
     }

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -321,16 +321,16 @@ impl FileDialog {
             show_files = true;
         }
 
-        if mode == DialogMode::SaveFile {
-            self.file_name_input
-                .clone_from(&self.config.default_file_name);
-        }
-
         self.selected_file_filter = None;
         self.selected_save_extension = None;
 
         self.set_default_file_filter();
         self.set_default_save_extension();
+
+        if mode == DialogMode::SaveFile {
+            self.file_name_input
+                .clone_from(&self.config.default_file_name);
+        }
 
         self.mode = mode;
         self.state = DialogState::Open;

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -645,6 +645,32 @@ impl FileDialog {
         self
     }
 
+    /// Adds a new file extension that the user can select in a dropdown widget when
+    /// saving a file.
+    ///
+    /// NOTE: The name must be unique. If an extension with the same name already exists,
+    ///       it will be overwritten.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Display name of the save extension.
+    /// * `file_extension` - The file extension to use.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use egui_file_dialog::FileDialogConfig;
+    ///
+    /// let config = FileDialog::default()
+    ///     .add_save_extension("PNG files", "png"))
+    ///     .add_save_extension("JPG files", "jpg"))
+    /// ```
+    pub fn add_save_extension(mut self, name: &str, file_extension: String) -> Self {
+        self.config = self.config.add_save_extension(name, file_extension);
+        self
+    }
+
     /// Name of the file filter to be selected by default.
     ///
     /// No file filter is selected if there is no file filter with that name.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -328,8 +328,9 @@ impl FileDialog {
         self.set_default_save_extension();
 
         if mode == DialogMode::SaveFile {
-            self.file_name_input
-                .clone_from(&self.config.default_file_name);
+            if let Some(name) = &self.config.default_file_name {
+                self.file_name_input.clone_from(name);
+            }
         }
 
         self.mode = mode;
@@ -512,7 +513,7 @@ impl FileDialog {
 
     /// Sets the default file name when opening the dialog in `DialogMode::SaveFile` mode.
     pub fn default_file_name(mut self, name: &str) -> Self {
-        self.config.default_file_name = name.to_string();
+        self.config.default_file_name = Some(name.to_owned());
         self
     }
 
@@ -2807,8 +2808,11 @@ impl FileDialog {
         if let Some(ex) = extension {
             self.selected_save_extension =  Some(ex.id);
 
+            let dot_count = self.file_name_input.chars().filter(|c| *c == '.').count();
+            let use_simple = dot_count == 1 && self.file_name_input.chars().nth(0) == Some('.');
+
             let mut p = PathBuf::from(&self.file_name_input);
-            if p.set_extension(&ex.file_extension) {
+            if !use_simple && p.set_extension(&ex.file_extension) {
                 self.file_name_input = p.to_string_lossy().into_owned();
             } else {
                 self.file_name_input = format!(".{}", ex.file_extension);

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1959,9 +1959,7 @@ impl FileDialog {
 
     /// Highlights the characters inside the file name input until the file extension.
     /// Do not forget to store these changes after calling this function:
-    /// ```
-    /// output.state.store(ui.ctx(), output.response.id);
-    /// ```
+    /// `output.state.store(ui.ctx(), output.response.id);`
     fn highlight_file_name_input(&self, output: &mut egui::text_edit::TextEditOutput) {
         if let Some(pos) = self.file_name_input.rfind('.') {
             let range = if pos == 0 {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2055,16 +2055,6 @@ impl FileDialog {
                         select_extension = Some(Some(extension.clone()));
                     }
                 }
-
-                if ui
-                    .selectable_label(
-                        selected_extension.is_none(),
-                        &self.config.labels.save_extension_any,
-                    )
-                    .clicked()
-                {
-                    select_extension = Some(None);
-                }
             });
 
         if let Some(i) = select_extension {

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -675,7 +675,7 @@ impl FileDialog {
     ///
     /// let config = FileDialog::default()
     ///     .add_save_extension("PNG files", "png")
-    ///     .add_save_extension("JPG files", "jpg")
+    ///     .add_save_extension("JPG files", "jpg");
     /// ```
     pub fn add_save_extension(mut self, name: &str, file_extension: &str) -> Self {
         self.config = self.config.add_save_extension(name, file_extension);

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -3312,12 +3312,24 @@ impl FileDialog {
     fn load_directory_content(&mut self, path: &Path) {
         self.config.storage.last_visited_dir = Some(path.to_path_buf());
 
+        let selected_file_filter = match self.mode {
+            DialogMode::PickFile | DialogMode::PickMultiple => self.get_selected_file_filter(),
+            _ => None,
+        };
+
+        let selected_save_extension = if self.mode == DialogMode::SaveFile {
+            self.get_selected_save_extension()
+                .map(|e| e.file_extension.as_str())
+        } else {
+            None
+        };
+
         self.directory_content = DirectoryContent::from_path(
             &self.config,
             path,
             self.show_files,
-            self.get_selected_file_filter(),
-            self.get_selected_save_extension().map(|e| e.file_extension.as_str()),
+            selected_file_filter,
+            selected_save_extension,
             self.config.file_system.clone(),
         );
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2047,7 +2047,7 @@ impl FileDialog {
                     let selected = selected_extension.is_some_and(|s| s.id == extension.id);
 
                     if ui
-                        .selectable_label(selected, &extension.to_string())
+                        .selectable_label(selected, extension.to_string())
                         .clicked()
                     {
                         select_extension = Some(Some(extension.clone()));
@@ -2778,7 +2778,7 @@ impl FileDialog {
 
     /// Selects the given file filter and applies the appropriate filters.
     fn select_file_filter(&mut self, filter: Option<FileFilter>) {
-        self.selected_file_filter = filter.and_then(|f| Some(f.id));
+        self.selected_file_filter = filter.map(|f| f.id);
         self.selected_item = None;
         self.refresh();
     }
@@ -3317,8 +3317,7 @@ impl FileDialog {
             path,
             self.show_files,
             self.get_selected_file_filter(),
-            self.get_selected_save_extension()
-                .and_then(|e| Some(e.file_extension.as_str())),
+            self.get_selected_save_extension().map(|e| e.file_extension.as_str()),
             self.config.file_system.clone(),
         );
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -677,14 +677,8 @@ impl FileDialog {
     ///     .add_save_extension("PNG files", "png")
     ///     .add_save_extension("JPG files", "jpg")
     /// ```
-    pub fn add_save_extension(
-        mut self,
-        name: &str,
-        file_extension: &str,
-    ) -> Self {
-        self.config = self
-            .config
-            .add_save_extension(name, file_extension);
+    pub fn add_save_extension(mut self, name: &str, file_extension: &str) -> Self {
+        self.config = self.config.add_save_extension(name, file_extension);
         self
     }
 
@@ -2810,7 +2804,7 @@ impl FileDialog {
     /// Selects the given save extension.
     fn select_save_extension(&mut self, extension: Option<SaveExtension>) {
         if let Some(ex) = extension {
-            self.selected_save_extension =  Some(ex.id);
+            self.selected_save_extension = Some(ex.id);
 
             // Prevent `PathBuf::set_extension` to append the file extension when there is
             // already one without a file name. For example `.png` would be changed to `.png.txt`

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -513,7 +513,7 @@ impl FileDialog {
 
     /// Sets the default file name when opening the dialog in `DialogMode::SaveFile` mode.
     pub fn default_file_name(mut self, name: &str) -> Self {
-        self.config.default_file_name = name.to_owned();
+        name.clone_into(&mut self.config.default_file_name);
         self
     }
 
@@ -2827,7 +2827,7 @@ impl FileDialog {
         if !use_simple && p.set_extension(extension) {
             self.file_name_input = p.to_string_lossy().into_owned();
         } else {
-            self.file_name_input = format!(".{}", extension);
+            self.file_name_input = format!(".{extension}");
         }
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -2808,6 +2808,9 @@ impl FileDialog {
         if let Some(ex) = extension {
             self.selected_save_extension =  Some(ex.id);
 
+            // Prevent `PathBuf::set_extension` to append the file extension when there is
+            // already one without a file name. For example `.png` would be changed to `.png.txt`
+            // when using `PathBuf::set_extension`.
             let dot_count = self.file_name_input.chars().filter(|c| *c == '.').count();
             let use_simple = dot_count == 1 && self.file_name_input.chars().nth(0) == Some('.');
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1859,8 +1859,8 @@ impl FileDialog {
 
         self.ui_update_selection_preview(ui, button_size);
 
-        if self.mode == DialogMode::SaveFile {
-            ui.add_space(ui.style().spacing.item_spacing.y * 2.0);
+        if self.mode == DialogMode::SaveFile && self.config.save_extensions.is_empty() {
+            ui.add_space(ui.style().spacing.item_spacing.y);
         }
 
         self.ui_update_action_buttons(ui, button_size);
@@ -1917,6 +1917,7 @@ impl FileDialog {
                     let response = ui.add(
                         egui::TextEdit::singleline(&mut self.file_name_input)
                             .cursor_at_end(false)
+                            .margin(egui::Margin::symmetric(4, 3))
                             .desired_width(scroll_bar_width - item_spacing.x),
                     );
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -141,8 +141,10 @@ pub struct FileDialog {
     file_name_input_error: Option<String>,
     /// If the file name input text field should request focus in the next frame.
     file_name_input_request_focus: bool,
-    /// The file filter the user selected
+    /// The file filter the user selected.
     selected_file_filter: Option<egui::Id>,
+    /// The save extension that the user selected.
+    selected_save_extension: Option<egui::Id>,
 
     /// If we should scroll to the item selected by the user in the next frame.
     scroll_to_selection: bool,
@@ -222,6 +224,7 @@ impl FileDialog {
             file_name_input_error: None,
             file_name_input_request_focus: true,
             selected_file_filter: None,
+            selected_save_extension: None,
 
             scroll_to_selection: false,
             search_value: String::new(),
@@ -323,14 +326,8 @@ impl FileDialog {
                 .clone_from(&self.config.default_file_name);
         }
 
-        // Select the default file filter
-        if let Some(name) = &self.config.default_file_filter {
-            for filter in &self.config.file_filters {
-                if filter.name == name.as_str() {
-                    self.selected_file_filter = Some(filter.id);
-                }
-            }
-        }
+        self.set_default_file_filter();
+        self.set_default_save_extension();
 
         self.mode = mode;
         self.state = DialogState::Open;
@@ -645,6 +642,14 @@ impl FileDialog {
         self
     }
 
+    /// Name of the file filter to be selected by default.
+    ///
+    /// No file filter is selected if there is no file filter with that name.
+    pub fn default_file_filter(mut self, name: &str) -> Self {
+        self.config.default_file_filter = Some(name.to_string());
+        self
+    }
+
     /// Adds a new file extension that the user can select in a dropdown widget when
     /// saving a file.
     ///
@@ -671,11 +676,11 @@ impl FileDialog {
         self
     }
 
-    /// Name of the file filter to be selected by default.
+    /// Name of the file extension to be selected by default when saving a file.
     ///
-    /// No file filter is selected if there is no file filter with that name.
-    pub fn default_file_filter(mut self, name: &str) -> Self {
-        self.config.default_file_filter = Some(name.to_string());
+    /// No file extension is selected if there is no extension with that name.
+    pub fn default_save_extension(mut self, name: &str) -> Self {
+        self.config.default_save_extension = Some(name.to_string());
         self
     }
 
@@ -2709,6 +2714,28 @@ impl FileDialog {
     fn get_selected_file_filter(&self) -> Option<&FileFilter> {
         self.selected_file_filter
             .and_then(|id| self.config.file_filters.iter().find(|p| p.id == id))
+    }
+
+    /// Sets the default file filter to use.
+    fn set_default_file_filter(&mut self) {
+        if let Some(name) = &self.config.default_file_filter {
+            for filter in &self.config.file_filters {
+                if filter.name == name.as_str() {
+                    self.selected_file_filter = Some(filter.id);
+                }
+            }
+        }
+    }
+
+    /// Sets the save extension to use.
+    fn set_default_save_extension(&mut self) {
+        if let Some(name) = &self.config.default_save_extension {
+            for extension in &self.config.save_extensions {
+                if extension.name == name.as_str() {
+                    self.selected_save_extension = Some(extension.id);
+                }
+            }
+        }
     }
 
     /// Gets a filtered iterator of the directory content of this object.

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -663,8 +663,6 @@ impl FileDialog {
     ///
     /// * `name` - Display name of the save extension.
     /// * `file_extension` - The file extension to use.
-    /// * `display_extension` - If the extension should be displayed next to its name.
-    ///    For example: "PNG Files (png)" when enabled or "PNG Files" when disabled.
     ///
     /// # Examples
     ///
@@ -673,18 +671,17 @@ impl FileDialog {
     /// use egui_file_dialog::FileDialog;
     ///
     /// let config = FileDialog::default()
-    ///     .add_save_extension("PNG files", "png", true)
-    ///     .add_save_extension("JPG files", "jpg", true)
+    ///     .add_save_extension("PNG files", "png")
+    ///     .add_save_extension("JPG files", "jpg")
     /// ```
     pub fn add_save_extension(
         mut self,
         name: &str,
         file_extension: &str,
-        display_extension: bool,
     ) -> Self {
         self.config = self
             .config
-            .add_save_extension(name, file_extension, display_extension);
+            .add_save_extension(name, file_extension);
         self
     }
 

--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -323,7 +323,8 @@ impl FileDialog {
 
         if mode == DialogMode::SaveFile {
             self.file_name_input_request_focus = true;
-            self.file_name_input.clone_from(&self.config.default_file_name);
+            self.file_name_input
+                .clone_from(&self.config.default_file_name);
         }
 
         self.selected_file_filter = None;


### PR DESCRIPTION
This PR adds the new methods `FileDialog::add_save_extension`, `FileDialogConfig::add_save_extension` and `FileDialog::default_save_extension` which allow adding a file extension that will be shown to the user in a dropdown list when saving a file. This also automatically adds the file extension to the file name input.

For example:
```rust
FileDialog::new()
            .add_save_extension("Picture", "png")
            .add_save_extension("Rust Source File", "rs")
            .add_save_extension("Configuration File", "toml")
            .default_save_extension("Picture");
```
Will create the following options with "Picture" beeing selected by default.

![Screenshot_20250309_180124](https://github.com/user-attachments/assets/8115ea9c-eebe-4938-8239-6beb6a98098e)

Further changes:
- Changed the default file name from an empty string to `Untitled`
- Automatically highlight file name

TODO:
- [x] Fix height of the dropdown menu
- [x] Fix that the file extension is appended when one already exists without a file name. Aka when the file name starts with `.` and that is the only one in the name. For example, `.png` becomes `.png.txt` when the extension is changed.
- [x] Test with default file name setting

Closes #138 