### PR TITLE
fix: use virtual file system to retrieve the current working directory

### DIFF
--- a/src/file_dialog.rs
+++ b/src/file_dialog.rs
@@ -1464,7 +1464,7 @@ impl FileDialog {
             ui.close_menu();
         }
 
-        let working_dir = std::env::current_dir();
+        let working_dir = self.config.file_system.current_dir();
 
         if self.config.show_working_directory_button
             && working_dir.is_ok()


### PR DESCRIPTION
Fixed the `Go to Working Directory` shortcut added with #246 not using the virtual file system.