### PR TITLE
feat: path context menu from navigation bar

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,7 +8,6 @@ use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::data::DirectoryEntry;
 use crate::{FileSystem, NativeFileSystem};
 
 /// Contains data of the `FileDialog` that should be stored persistently.
@@ -16,7 +15,7 @@ use crate::{FileSystem, NativeFileSystem};
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FileDialogStorage {
     /// The folders the user pinned to the left sidebar.
-    pub pinned_folders: Vec<DirectoryEntry>,
+    pub pinned_folders: Vec<PathBuf>,
     /// If hidden files and folders should be listed inside the directory view.
     pub show_hidden: bool,
     /// If system files should be listed inside the directory view.


### PR DESCRIPTION
This now makes it possible to open the path context menu from a path segment in the navigation bar. Additionally, the pinned icon is now also displayed in the navigation bar.
Furthermore, only the path is now stored in `FileDialogStorage`, instead of the entire `DirectoryEntry` object. This improves performance, but the stored data will be deleted upon first startup because the current config is invalid.

Closes #252 